### PR TITLE
Removing event listener (resize and keydown) component will unmount

### DIFF
--- a/dist/DateTimeRangeContainer.js
+++ b/dist/DateTimeRangeContainer.js
@@ -1,0 +1,294 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = exports.mobileBreakPoint = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _reactDom = require("react-dom");
+
+require("./style/DateTimeRange.css");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _reactMomentProptypes = _interopRequireDefault(require("react-moment-proptypes"));
+
+var _DateTimeRangePicker = require("./DateTimeRangePicker");
+
+var _PropValidation = require("./utils/PropValidation");
+
+var _StyleUtils = require("./utils/StyleUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var mobileBreakPoint = 680;
+exports.mobileBreakPoint = mobileBreakPoint;
+
+var DateTimeRangeContainer =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(DateTimeRangeContainer, _React$Component);
+
+  function DateTimeRangeContainer(props) {
+    var _this;
+
+    _classCallCheck(this, DateTimeRangeContainer);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(DateTimeRangeContainer).call(this, props));
+    _this.state = {
+      visible: false,
+      x: 0,
+      y: 0,
+      screenWidthToTheRight: 0,
+      containerClassName: ''
+    };
+    var propValidationReturn = (0, _PropValidation.propValidation)(_this.props);
+
+    if (propValidationReturn !== true) {
+      alert(propValidationReturn);
+    }
+
+    _this.resize = _this.resize.bind(_assertThisInitialized(_this));
+    _this.onClickContainerHandler = _this.onClickContainerHandler.bind(_assertThisInitialized(_this));
+    _this.handleOutsideClick = _this.handleOutsideClick.bind(_assertThisInitialized(_this));
+    _this.changeVisibleState = _this.changeVisibleState.bind(_assertThisInitialized(_this));
+    _this.keyDown = _this.keyDown.bind(_assertThisInitialized(_this));
+    return _this;
+  }
+
+  _createClass(DateTimeRangeContainer, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      window.addEventListener('resize', this.resize);
+      document.addEventListener('keydown', this.keyDown, false);
+      this.resize();
+    }
+  }, {
+    key: "componentWillMount",
+    value: function componentWillMount() {
+      window.removeEventListener('resize', this.resize);
+      document.removeEventListener('keydown', this.keyDown, false);
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      window.removeEventListener('resize', this.resize);
+      document.removeEventListener('keydown', this.keyDown, false);
+    }
+  }, {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(prevProps) {
+      // If the left mode prop has been updated from the Parent treat it like a rezise
+      // and adjust the layout accordingly
+      if (prevProps.leftMode != this.props.leftMode) {
+        this.resize();
+      }
+    }
+  }, {
+    key: "resize",
+    value: function resize() {
+      var domNode = (0, _reactDom.findDOMNode)(this).children[0];
+      var mobileModeActive = !this.props.noMobileMode; // If no mobile mode prop not set then allow mobile mode
+
+      var mobileModeForce = this.props.forceMobileMode; // If force mobile mode prop is set then force mobile mode
+
+      var boundingClientRect = domNode.getBoundingClientRect();
+      var widthRightOfThis = window.innerWidth - boundingClientRect.x;
+
+      if (widthRightOfThis < mobileBreakPoint && mobileModeActive || mobileModeForce) {
+        // If in small mode put picker in middle of child
+        var childMiddle = boundingClientRect.width / 2;
+        var containerMiddle = 144;
+        var newY = childMiddle - containerMiddle;
+        this.setState({
+          x: boundingClientRect.height + 5,
+          y: newY,
+          screenWidthToTheRight: widthRightOfThis,
+          containerClassName: 'daterangepicker'
+        });
+      } else if (this.props.leftMode) {
+        this.setState({
+          x: boundingClientRect.height + 5,
+          y: -660,
+          screenWidthToTheRight: widthRightOfThis,
+          containerClassName: 'daterangepicker daterangepickerleft'
+        });
+      } else {
+        this.setState({
+          x: boundingClientRect.height + 5,
+          y: 0,
+          screenWidthToTheRight: widthRightOfThis,
+          containerClassName: 'daterangepicker'
+        });
+      }
+    }
+  }, {
+    key: "keyDown",
+    value: function keyDown(e) {
+      if (e.keyCode === 27) {
+        this.setState({
+          visible: false
+        });
+        document.removeEventListener('keydown', this.keyDown, false);
+      }
+    }
+  }, {
+    key: "onClickContainerHandler",
+    value: function onClickContainerHandler(event) {
+      if (!this.state.visible) {
+        document.addEventListener('click', this.handleOutsideClick, false);
+        document.addEventListener('keydown', this.keyDown, false);
+        this.changeVisibleState();
+      }
+    }
+  }, {
+    key: "handleOutsideClick",
+    value: function handleOutsideClick(e) {
+      // ignore clicks on the component itself
+      if (this.state.visible) {
+        if (this.container.contains(e.target)) {
+          return;
+        }
+
+        document.removeEventListener('click', this.handleOutsideClick, false);
+        this.changeVisibleState();
+      }
+    }
+  }, {
+    key: "changeVisibleState",
+    value: function changeVisibleState() {
+      this.setState(function (prevState) {
+        return {
+          visible: !prevState.visible
+        };
+      });
+    }
+  }, {
+    key: "shouldShowPicker",
+    value: function shouldShowPicker() {
+      var mobileModeActive = !this.props.noMobileMode; // If no mobile mode prop not set then allow mobile mode
+
+      var mobileModeForce = this.props.forceMobileMode; // If force mobile mode prop is set then force mobile mode
+
+      if (this.state.visible && (this.state.screenWidthToTheRight < mobileBreakPoint && mobileModeActive || mobileModeForce)) {
+        return 'block';
+      } else if (this.state.visible) {
+        return 'flex';
+      } else {
+        return 'none';
+      }
+    }
+  }, {
+    key: "renderPicker",
+    value: function renderPicker() {
+      return _react.default.createElement(_DateTimeRangePicker.DateTimeRangePicker, {
+        ranges: this.props.ranges,
+        start: this.props.start,
+        end: this.props.end,
+        local: this.props.local,
+        applyCallback: this.props.applyCallback,
+        rangeCallback: this.props.rangeCallback,
+        autoApply: this.props.autoApply,
+        changeVisibleState: this.changeVisibleState,
+        screenWidthToTheRight: this.state.screenWidthToTheRight,
+        maxDate: this.props.maxDate,
+        descendingYears: this.props.descendingYears,
+        years: this.props.years,
+        pastSearchFriendly: this.props.pastSearchFriendly,
+        smartMode: this.props.smartMode,
+        style: this.props.style,
+        darkMode: this.props.darkMode,
+        noMobileMode: this.props.noMobileMode,
+        forceMobileMode: this.props.forceMobileMode,
+        standalone: this.props.standalone
+      });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
+
+      var showPicker = this.shouldShowPicker();
+      var x = this.state.x;
+      var y = this.state.y;
+      var theme = this.props.darkMode ? _StyleUtils.darkTheme : _StyleUtils.lightTheme; // Special standalone render
+
+      if (this.props.standalone && this.props.style && this.props.style.standaloneLayout) {
+        return _react.default.createElement("div", {
+          style: this.props.style.standaloneLayout
+        }, this.renderPicker());
+      }
+
+      return _react.default.createElement("div", {
+        id: "DateRangePickerContainer",
+        className: "daterangepickercontainer",
+        onClick: this.onClickContainerHandler,
+        ref: function ref(container) {
+          _this2.container = container;
+        }
+      }, this.props.children && _react.default.createElement("div", {
+        id: "DateRangePickerChildren"
+      }, this.props.children), _react.default.createElement("div", null, _react.default.createElement("div", {
+        id: "daterangepicker",
+        className: this.state.containerClassName,
+        style: _objectSpread({
+          top: x,
+          left: y,
+          display: showPicker
+        }, theme)
+      }, this.renderPicker())));
+    }
+  }]);
+
+  return DateTimeRangeContainer;
+}(_react.default.Component);
+
+DateTimeRangeContainer.propTypes = {
+  ranges: _propTypes.default.object.isRequired,
+  start: _reactMomentProptypes.default.momentObj,
+  end: _reactMomentProptypes.default.momentObj,
+  local: _propTypes.default.object.isRequired,
+  applyCallback: _propTypes.default.func.isRequired,
+  rangeCallback: _propTypes.default.func,
+  autoApply: _propTypes.default.bool,
+  maxDate: _reactMomentProptypes.default.momentObj,
+  descendingYears: _propTypes.default.bool,
+  pastSearchFriendly: _propTypes.default.bool,
+  years: _propTypes.default.array,
+  smartMode: _propTypes.default.bool,
+  darkMode: _propTypes.default.bool,
+  noMobileMode: _propTypes.default.bool,
+  forceMobileMode: _propTypes.default.bool,
+  style: _propTypes.default.object,
+  children: _propTypes.default.any,
+  leftMode: _propTypes.default.bool,
+  standalone: _propTypes.default.bool
+};
+var _default = DateTimeRangeContainer;
+exports.default = _default;

--- a/dist/DateTimeRangePicker.js
+++ b/dist/DateTimeRangePicker.js
@@ -1,0 +1,621 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.DateTimeRangePicker = exports.momentFormat = exports.ModeEnum = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("./style/DateTimeRange.css");
+
+var _reactDotFragment = _interopRequireDefault(require("react-dot-fragment"));
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _reactMomentProptypes = _interopRequireDefault(require("react-moment-proptypes"));
+
+var _Ranges = _interopRequireDefault(require("./ranges/Ranges"));
+
+var _DatePicker = _interopRequireDefault(require("./date_picker/DatePicker"));
+
+var _TimeFunctionUtils = require("./utils/TimeFunctionUtils");
+
+var _DateSelectedUtils = require("./utils/DateSelectedUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var ModeEnum = Object.freeze({
+  start: 'start',
+  end: 'end'
+});
+exports.ModeEnum = ModeEnum;
+var momentFormat = 'DD-MM-YYYY HH:mm';
+exports.momentFormat = momentFormat;
+
+var DateTimeRangePicker =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(DateTimeRangePicker, _React$Component);
+
+  function DateTimeRangePicker(props) {
+    var _this;
+
+    _classCallCheck(this, DateTimeRangePicker);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(DateTimeRangePicker).call(this, props));
+    var ranges = {};
+    var customRange = {
+      'Custom Range': 'Custom Range'
+    };
+    Object.assign(ranges, _this.props.ranges, customRange);
+    var localMomentFormat = 'DD-MM-YYYY HH:mm';
+
+    if (_this.props.local && _this.props.local.format) {
+      exports.momentFormat = momentFormat = _this.props.local.format;
+      localMomentFormat = _this.props.local.format;
+    }
+
+    _this.state = {
+      selectedRange: 0,
+      selectingModeFrom: true,
+      ranges: ranges,
+      start: _this.props.start,
+      startLabel: _this.props.start.format(localMomentFormat),
+      end: _this.props.end,
+      endLabel: _this.props.end.format(localMomentFormat),
+      focusDate: false,
+      momentFormat: localMomentFormat
+    };
+
+    _this.bindToFunctions();
+
+    return _this;
+  }
+
+  _createClass(DateTimeRangePicker, [{
+    key: "bindToFunctions",
+    value: function bindToFunctions() {
+      this.rangeSelectedCallback = this.rangeSelectedCallback.bind(this);
+      this.dateSelectedNoTimeCallback = this.dateSelectedNoTimeCallback.bind(this);
+      this.timeChangeCallback = this.timeChangeCallback.bind(this);
+      this.dateTextFieldCallback = this.dateTextFieldCallback.bind(this);
+      this.onChangeDateTextHandlerCallback = this.onChangeDateTextHandlerCallback.bind(this);
+      this.changeSelectingModeCallback = this.changeSelectingModeCallback.bind(this);
+      this.applyCallback = this.applyCallback.bind(this);
+      this.keyboardCellCallback = this.keyboardCellCallback.bind(this);
+      this.focusOnCallback = this.focusOnCallback.bind(this);
+      this.cellFocusedCallback = this.cellFocusedCallback.bind(this);
+    }
+  }, {
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      this.setToRangeValue(this.state.start, this.state.end);
+    }
+  }, {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(prevProps) {
+      if (!this.props.start.isSame(prevProps.start) || !this.props.end.isSame(prevProps.end)) {
+        this.updateStartEndAndLabels(this.props.start, this.props.end);
+      }
+    }
+  }, {
+    key: "applyCallback",
+    value: function applyCallback() {
+      this.props.applyCallback(this.state.start, this.state.end);
+      this.props.changeVisibleState();
+    }
+  }, {
+    key: "checkAutoApplyActiveApplyIfActive",
+    value: function checkAutoApplyActiveApplyIfActive(startDate, endDate) {
+      if (this.props.autoApply) {
+        this.props.applyCallback(startDate, endDate);
+      }
+    }
+  }, {
+    key: "rangeSelectedCallback",
+    value: function rangeSelectedCallback(index, value) {
+      // If Past Max Date Dont allow update
+      var start;
+      var end;
+
+      if (value !== 'Custom Range') {
+        start = this.state.ranges[value][0];
+        end = this.state.ranges[value][1];
+
+        if ((0, _DateSelectedUtils.pastMaxDate)(start, this.props.maxDate, true) || (0, _DateSelectedUtils.pastMaxDate)(end, this.props.maxDate, true)) {
+          return false;
+        }
+      } // Else update state to new selected index and update start and end time
+
+
+      this.setState({
+        selectedRange: index
+      });
+
+      if (value !== 'Custom Range') {
+        this.updateStartEndAndLabels(start, end);
+      }
+
+      if (this.props.rangeCallback) {
+        this.props.rangeCallback(index, value);
+      }
+
+      if (value !== 'Custom Range') {
+        this.checkAutoApplyActiveApplyIfActive(start, end);
+      }
+    }
+  }, {
+    key: "setToRangeValue",
+    value: function setToRangeValue(startDate, endDate) {
+      var _this2 = this;
+
+      var rangesArray = Object.keys(this.state.ranges).map(function (key) {
+        return _this2.state.ranges[key];
+      });
+
+      for (var i = 0; i < rangesArray.length; i++) {
+        if (rangesArray[i] === 'Custom Range') {
+          continue;
+        } else if (rangesArray[i][0].isSame(startDate, 'minutes') && rangesArray[i][1].isSame(endDate, 'minutes')) {
+          this.setState({
+            selectedRange: i
+          });
+          return;
+        }
+      }
+
+      this.setToCustomRange();
+    }
+  }, {
+    key: "setToCustomRange",
+    value: function setToCustomRange() {
+      var _this3 = this;
+
+      var rangesArray = Object.keys(this.state.ranges).map(function (key) {
+        return _this3.state.ranges[key];
+      });
+
+      for (var i = 0; i < rangesArray.length; i++) {
+        if (rangesArray[i] === 'Custom Range') {
+          this.setState({
+            selectedRange: i
+          });
+        }
+      }
+    }
+  }, {
+    key: "updateStartEndAndLabels",
+    value: function updateStartEndAndLabels(newStart, newEnd) {
+      this.setState({
+        start: newStart,
+        startLabel: newStart.format(this.state.momentFormat),
+        end: newEnd,
+        endLabel: newEnd.format(this.state.momentFormat)
+      });
+    } // Currently called from Cell selection
+
+  }, {
+    key: "dateSelectedNoTimeCallback",
+    value: function dateSelectedNoTimeCallback(cellDate, cellMode) {
+      // If in smart mode get the new date selecting mode from the selectingMode (Changes between too and from)
+      // If in non smart mode take the new date selecting mode from the callback mode param
+      var isSelectingModeFrom;
+
+      if (this.props.smartMode) {
+        isSelectingModeFrom = this.state.selectingModeFrom;
+      } else if (cellMode === ModeEnum.start) {
+        isSelectingModeFrom = true;
+      } else {
+        isSelectingModeFrom = false;
+      } // Get the new dates from the dates selected by the user
+
+
+      var newDates = (0, _DateSelectedUtils.datePicked)(this.state.start, this.state.end, cellDate, isSelectingModeFrom, this.props.smartMode); // unpack the new dates and set them
+
+      var startDate = newDates.startDate;
+      var endDate = newDates.endDate;
+      var newStart = this.duplicateMomentTimeFromState(startDate, true);
+      var newEnd = this.duplicateMomentTimeFromState(endDate, false);
+      this.updateStartEndAndLabels(newStart, newEnd);
+      this.setToRangeValue(newStart, newEnd); // If Smart Mode is active change the selecting mode to opposite of what was just pressed
+
+      if (this.props.smartMode) {
+        this.setState(function (prevState) {
+          return {
+            selectingModeFrom: !prevState.selectingModeFrom
+          };
+        });
+      }
+
+      this.checkAutoApplyActiveApplyIfActive(newStart, newEnd);
+    }
+  }, {
+    key: "changeSelectingModeCallback",
+    value: function changeSelectingModeCallback(selectingModeFromParam) {
+      if (this.props.smartMode) {
+        this.setState({
+          selectingModeFrom: selectingModeFromParam
+        });
+      }
+    }
+  }, {
+    key: "duplicateMomentTimeFromState",
+    value: function duplicateMomentTimeFromState(date, startDate) {
+      var state;
+
+      if (startDate) {
+        state = this.state.start;
+      } else {
+        state = this.state.end;
+      }
+
+      var newDate = [date.year(), date.month(), date.date(), state.hours(), state.minutes(), state.seconds()];
+      return (0, _moment.default)(newDate);
+    }
+  }, {
+    key: "timeChangeCallback",
+    value: function timeChangeCallback(newHour, newMinute, mode) {
+      if (mode === 'start') {
+        this.updateStartTime(newHour, newMinute, mode);
+      } else if (mode === 'end') {
+        this.updateEndTime(newHour, newMinute, mode);
+      }
+    }
+  }, {
+    key: "updateStartTime",
+    value: function updateStartTime(newHour, newMinute, mode) {
+      this.updateTime(this.state.start, newHour, newMinute, mode, 'start', 'startLabel');
+    }
+  }, {
+    key: "updateEndTime",
+    value: function updateEndTime(newHour, newMinute, mode) {
+      this.updateTime(this.state.end, newHour, newMinute, mode, 'end', 'endLabel');
+    }
+  }, {
+    key: "updateTime",
+    value: function updateTime(origDate, newHour, newMinute, mode, stateDateToChangeName, stateLabelToChangeName) {
+      var date = (0, _moment.default)(origDate);
+      date.hours(newHour);
+      date.minutes(newMinute); // If Past Max Date Dont allow update
+
+      if ((0, _DateSelectedUtils.pastMaxDate)(date, this.props.maxDate, true)) {
+        return false;
+      } // If Valid Time Change allow the change else if in smart mode
+      // set new start and end times to be minute ahead/behind the new date
+      // else dont allow the change
+
+
+      if ((0, _TimeFunctionUtils.isValidTimeChange)(mode, date, this.state.start, this.state.end)) {
+        var _this$setState;
+
+        this.setState((_this$setState = {}, _defineProperty(_this$setState, stateDateToChangeName, date), _defineProperty(_this$setState, stateLabelToChangeName, date.format(this.state.momentFormat)), _this$setState));
+        this.updateTimeCustomRangeUpdator(stateDateToChangeName, date);
+
+        if (stateDateToChangeName === 'end') {
+          this.checkAutoApplyActiveApplyIfActive(this.state.start, date);
+        } else {
+          this.checkAutoApplyActiveApplyIfActive(date, this.state.end);
+        }
+      } else if (this.props.smartMode) {
+        var newDate = (0, _moment.default)(date);
+
+        if (mode === 'start') {
+          newDate.add(1, 'minute');
+          this.updateStartEndAndLabels(date, newDate);
+          this.setToRangeValue(date, newDate);
+          this.checkAutoApplyActiveApplyIfActive(date, newDate);
+        } else {
+          newDate.subtract(1, 'minute');
+          this.updateStartEndAndLabels(newDate, date);
+          this.setToRangeValue(newDate, date);
+          this.checkAutoApplyActiveApplyIfActive(newDate, date);
+        }
+      } else {
+        this.updateStartEndAndLabels(this.state.start, this.state.end);
+        this.setToRangeValue(this.state.start, this.state.end);
+        this.checkAutoApplyActiveApplyIfActive(this.state.start, this.state.end);
+      }
+    }
+  }, {
+    key: "updateTimeCustomRangeUpdator",
+    value: function updateTimeCustomRangeUpdator(stateDateToChangeName, date) {
+      if (stateDateToChangeName === 'start') {
+        this.setToRangeValue(date, this.state.end);
+      } else {
+        this.setToRangeValue(this.state.start, date);
+      }
+    }
+  }, {
+    key: "dateTextFieldCallback",
+    value: function dateTextFieldCallback(mode) {
+      if (mode === 'start') {
+        var newDate = (0, _moment.default)(this.state.startLabel, this.state.momentFormat);
+        var isValidNewDate = newDate.isValid();
+        var isSameOrBeforeEnd = newDate.isSameOrBefore(this.state.end, 'second');
+        var isAfterEndDate = newDate.isAfter(this.state.end);
+        this.updateDate(mode, newDate, isValidNewDate, isSameOrBeforeEnd, isAfterEndDate, 'start', 'startLabel');
+      } else {
+        var _newDate = (0, _moment.default)(this.state.endLabel, this.state.momentFormat);
+
+        var _isValidNewDate = _newDate.isValid();
+
+        var isBeforeStartDate = _newDate.isBefore(this.state.start);
+
+        var isSameOrAfterStartDate = _newDate.isSameOrAfter(this.state.start, 'second');
+
+        this.updateDate(mode, _newDate, _isValidNewDate, isSameOrAfterStartDate, isBeforeStartDate, 'end', 'endLabel');
+      }
+    }
+  }, {
+    key: "updateDate",
+    value: function updateDate(mode, newDate, isValidNewDate, isValidDateChange, isInvalidDateChange, stateDateToChangeName, stateLabelToChangeName) {
+      // If new date past max date dont allow change
+      if ((0, _DateSelectedUtils.pastMaxDate)(newDate, this.props.maxDate, true)) {
+        this.updateStartEndAndLabels(this.state.start, this.state.end);
+        return false;
+      } // Else if date valid and date change valid update the date,
+
+
+      if (isValidNewDate && isValidDateChange) {
+        var _this$setState2;
+
+        this.setState((_this$setState2 = {}, _defineProperty(_this$setState2, stateDateToChangeName, newDate), _defineProperty(_this$setState2, stateLabelToChangeName, newDate.format(this.state.momentFormat)), _this$setState2));
+        this.updateTimeCustomRangeUpdator(stateDateToChangeName, newDate);
+
+        if (stateDateToChangeName === 'end') {
+          this.checkAutoApplyActiveApplyIfActive(this.state.start, newDate);
+        } else {
+          this.checkAutoApplyActiveApplyIfActive(newDate, this.state.end);
+        }
+      } // If new date valid but date change invalid go into update invalid mode,
+      // adds/subtract 1 days from start/stop value
+      // Only do this if in smart mode though
+      else if (isValidNewDate && isInvalidDateChange && this.props.smartMode) {
+          this.updateInvalidDate(mode, newDate);
+        } else {
+          this.updateStartEndAndLabels(this.state.start, this.state.end);
+        }
+    }
+  }, {
+    key: "updateInvalidDate",
+    value: function updateInvalidDate(mode, newDate) {
+      if (mode === 'start') {
+        var newEndDate = (0, _moment.default)(newDate).add(1, 'day');
+        this.updateLabelsAndRangeValues(newDate, newEndDate);
+        this.checkAutoApplyActiveApplyIfActive(newDate, newEndDate);
+      } else {
+        var newStartDate = (0, _moment.default)(newDate).subtract(1, 'day');
+        this.updateStartEndAndLabels(newStartDate, newDate);
+        this.checkAutoApplyActiveApplyIfActive(newStartDate, newDate);
+      }
+    }
+  }, {
+    key: "updateLabelsAndRangeValues",
+    value: function updateLabelsAndRangeValues(startDate, endDate) {
+      this.updateStartEndAndLabels(startDate, endDate);
+      this.setToRangeValue(startDate, endDate);
+    }
+  }, {
+    key: "onChangeDateTextHandlerCallback",
+    value: function onChangeDateTextHandlerCallback(newValue, mode) {
+      if (mode === 'start') {
+        this.setState({
+          startLabel: newValue
+        });
+      } else if (mode === 'end') {
+        this.setState({
+          endLabel: newValue
+        });
+      }
+    }
+  }, {
+    key: "keyboardCellCallback",
+    value: function keyboardCellCallback(originalDate, newDate) {
+      var startDate;
+      var endDate; // If original date same as start and end date, and not in smart mode
+      // Then if cell end called allow new end date. Allow new start if cell start called
+      // Done for when the start and end date are the same
+
+      if (originalDate.isSame(this.state.start, 'day') && originalDate.isSame(this.state.end, 'day') && !this.props.smartMode) {
+        var activeElement = document.activeElement.id; // If Focused Cell is an end cell
+
+        if (activeElement && activeElement.includes('_cell_') && activeElement.includes('_end')) {
+          // Allow a new end date from the date calledback
+          startDate = (0, _moment.default)(this.state.start);
+          endDate = this.duplicateMomentTimeFromState(newDate, false); // EDGE CASE: Due to Cell focusing issues if Start and End date same
+          // due to Key press into each other, if you then press left it always
+          // calls it from the end cell so allow the end cell to handle this
+          // and switch to start when this occurs
+
+          if (!startDate.isSameOrBefore(endDate, 'second')) {
+            startDate = this.duplicateMomentTimeFromState(newDate, true);
+            endDate = (0, _moment.default)(this.state.end);
+          }
+        } else if (activeElement && activeElement.includes('_cell_') && activeElement.includes('_start')) {
+          startDate = this.duplicateMomentTimeFromState(newDate, true);
+          endDate = (0, _moment.default)(this.state.end);
+        }
+      }
+
+      if (!startDate && !endDate) {
+        // If original is the start date only, then set the start date to the new date
+        if (originalDate.isSame(this.state.start, 'day')) {
+          startDate = this.duplicateMomentTimeFromState(newDate, true);
+          endDate = (0, _moment.default)(this.state.end); //  Not in Smart Mode and Start Date after End Date then invalid change
+
+          if (!this.props.smartMode && startDate.isAfter(endDate, 'second')) {
+            return false;
+          }
+        } // End date only, set the end date to the new date
+        else {
+            startDate = (0, _moment.default)(this.state.start);
+            endDate = this.duplicateMomentTimeFromState(newDate, false); //  Not in Smart Mode and Start Date after End Date then invalid change
+
+            if (!this.props.smartMode && startDate.isAfter(endDate, 'second')) {
+              return false;
+            }
+          }
+      }
+
+      if (startDate.isSameOrBefore(endDate, 'second')) {
+        this.updateStartEndAndLabels(startDate, endDate);
+        this.checkAutoApplyActiveApplyIfActive(startDate, endDate);
+      } else {
+        this.updateStartEndAndLabels(endDate, startDate);
+        this.checkAutoApplyActiveApplyIfActive(endDate, startDate);
+      }
+
+      return true;
+    }
+  }, {
+    key: "focusOnCallback",
+    value: function focusOnCallback(date) {
+      if (date) {
+        this.setState({
+          focusDate: date
+        });
+      } else {
+        this.setState({
+          focusDate: false
+        });
+      }
+    }
+  }, {
+    key: "cellFocusedCallback",
+    value: function cellFocusedCallback(date) {
+      if (date.isSame(this.state.start, 'day')) {
+        this.changeSelectingModeCallback(true);
+      } else if (date.isSame(this.state.end, 'day')) {
+        this.changeSelectingModeCallback(false);
+      }
+    }
+  }, {
+    key: "renderStartDate",
+    value: function renderStartDate(local) {
+      var label = local && local.fromDate ? local.fromDate : "From Date";
+      return _react.default.createElement(_DatePicker.default, {
+        label: label,
+        date: this.state.start,
+        otherDate: this.state.end,
+        mode: ModeEnum.start,
+        dateSelectedNoTimeCallback: this.dateSelectedNoTimeCallback,
+        timeChangeCallback: this.timeChangeCallback,
+        dateTextFieldCallback: this.dateTextFieldCallback,
+        keyboardCellCallback: this.keyboardCellCallback,
+        focusOnCallback: this.focusOnCallback,
+        focusDate: this.state.focusDate,
+        cellFocusedCallback: this.cellFocusedCallback,
+        onChangeDateTextHandlerCallback: this.onChangeDateTextHandlerCallback,
+        dateLabel: this.state.startLabel,
+        selectingModeFrom: this.state.selectingModeFrom,
+        changeSelectingModeCallback: this.changeSelectingModeCallback,
+        applyCallback: this.applyCallback,
+        maxDate: this.props.maxDate,
+        local: this.props.local,
+        descendingYears: this.props.descendingYears,
+        years: this.props.years,
+        pastSearchFriendly: this.props.pastSearchFriendly,
+        smartMode: this.props.smartMode,
+        style: this.props.style,
+        darkMode: this.props.darkMode,
+        standalone: this.props.standalone
+      });
+    }
+  }, {
+    key: "renderEndDate",
+    value: function renderEndDate(local) {
+      var label = local && local.toDate ? local.toDate : "To Date";
+      return _react.default.createElement(_DatePicker.default, {
+        label: label,
+        date: this.state.end,
+        otherDate: this.state.start,
+        mode: ModeEnum.end,
+        dateSelectedNoTimeCallback: this.dateSelectedNoTimeCallback,
+        timeChangeCallback: this.timeChangeCallback,
+        dateTextFieldCallback: this.dateTextFieldCallback,
+        keyboardCellCallback: this.keyboardCellCallback,
+        focusOnCallback: this.focusOnCallback,
+        focusDate: this.state.focusDate,
+        cellFocusedCallback: this.cellFocusedCallback,
+        onChangeDateTextHandlerCallback: this.onChangeDateTextHandlerCallback,
+        dateLabel: this.state.endLabel,
+        changeVisibleState: this.props.changeVisibleState,
+        selectingModeFrom: this.state.selectingModeFrom,
+        changeSelectingModeCallback: this.changeSelectingModeCallback,
+        applyCallback: this.applyCallback,
+        maxDate: this.props.maxDate,
+        local: this.props.local,
+        descendingYears: this.props.descendingYears,
+        years: this.props.years,
+        pastSearchFriendly: this.props.pastSearchFriendly,
+        smartMode: this.props.smartMode,
+        enableButtons: true,
+        autoApply: this.props.autoApply,
+        style: this.props.style,
+        darkMode: this.props.darkMode,
+        standalone: this.props.standalone
+      });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      return _react.default.createElement(_reactDotFragment.default, null, _react.default.createElement(_Ranges.default, {
+        ranges: this.state.ranges,
+        selectedRange: this.state.selectedRange,
+        rangeSelectedCallback: this.rangeSelectedCallback,
+        screenWidthToTheRight: this.props.screenWidthToTheRight,
+        style: this.props.style,
+        noMobileMode: this.props.noMobileMode,
+        forceMobileMode: this.props.forceMobileMode
+      }), this.renderStartDate(this.props.local), this.renderEndDate(this.props.local));
+    }
+  }]);
+
+  return DateTimeRangePicker;
+}(_react.default.Component);
+
+exports.DateTimeRangePicker = DateTimeRangePicker;
+DateTimeRangePicker.propTypes = {
+  ranges: _propTypes.default.object.isRequired,
+  start: _reactMomentProptypes.default.momentObj.isRequired,
+  end: _reactMomentProptypes.default.momentObj.isRequired,
+  local: _propTypes.default.object.isRequired,
+  applyCallback: _propTypes.default.func.isRequired,
+  rangeCallback: _propTypes.default.func,
+  autoApply: _propTypes.default.bool,
+  maxDate: _reactMomentProptypes.default.momentObj,
+  descendingYears: _propTypes.default.bool,
+  years: _propTypes.default.array,
+  pastSearchFriendly: _propTypes.default.bool,
+  smartMode: _propTypes.default.bool,
+  changeVisibleState: _propTypes.default.func.isRequired,
+  screenWidthToTheRight: _propTypes.default.number.isRequired,
+  style: _propTypes.default.object,
+  darkMode: _propTypes.default.bool,
+  noMobileMode: _propTypes.default.bool,
+  forceMobileMode: _propTypes.default.bool,
+  standalone: _propTypes.default.bool
+};

--- a/dist/calendar/Calendar.js
+++ b/dist/calendar/Calendar.js
@@ -1,0 +1,252 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _reactMomentProptypes = _interopRequireDefault(require("react-moment-proptypes"));
+
+var _MonthYearSelector = _interopRequireDefault(require("./MonthYearSelector"));
+
+var _CalendarHeader = _interopRequireDefault(require("./CalendarHeader"));
+
+var _CalendarRows = _interopRequireDefault(require("./CalendarRows"));
+
+var _YearUtils = require("../utils/YearUtils");
+
+var _TimeFunctionUtils = require("../utils/TimeFunctionUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var Calendar =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(Calendar, _React$Component);
+
+  function Calendar(props) {
+    var _this;
+
+    _classCallCheck(this, Calendar);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(Calendar).call(this, props));
+    _this.state = {
+      month: 0,
+      year: 0
+    };
+    _this.changeMonthCallback = _this.changeMonthCallback.bind(_assertThisInitialized(_this));
+    _this.changeYearCallback = _this.changeYearCallback.bind(_assertThisInitialized(_this));
+    _this.changeMonthArrowsCallback = _this.changeMonthArrowsCallback.bind(_assertThisInitialized(_this));
+    return _this;
+  }
+
+  _createClass(Calendar, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      this.updateMonthYear();
+    }
+  }, {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(previousProps) {
+      if (!previousProps.date.isSame(this.props.date) || !previousProps.otherDate.isSame(this.props.otherDate)) {
+        this.updateMonthYear();
+      }
+    }
+  }, {
+    key: "updateMonthYear",
+    value: function updateMonthYear() {
+      var newMonth = (0, _TimeFunctionUtils.getMonth)(this.props.date, this.props.otherDate, this.props.mode, this.props.pastSearchFriendly, this.props.smartMode);
+      var newYear = (0, _TimeFunctionUtils.getYear)(this.props.date, this.props.otherDate, this.props.mode, this.props.pastSearchFriendly, this.props.smartMode);
+      this.setState({
+        month: newMonth,
+        year: newYear
+      });
+    }
+  }, {
+    key: "createMonths",
+    value: function createMonths(local) {
+      if (local && local.months) {
+        return local.months;
+      }
+
+      var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+      return months;
+    }
+  }, {
+    key: "changeMonthCallback",
+    value: function changeMonthCallback(event) {
+      for (var i = 0; i < event.target.length; i++) {
+        if (event.target[i].value === event.target.value) {
+          this.setState({
+            month: i
+          });
+        }
+      }
+    }
+  }, {
+    key: "changeMonthArrowsCallback",
+    value: function changeMonthArrowsCallback(isPreviousChange, isNextChange) {
+      var years = (0, _YearUtils.createYears)(this.props.years, this.props.descendingYears);
+      var monthLocal = parseInt(this.state.month);
+      var yearLocal = parseInt(this.state.year);
+      var newMonthYear;
+
+      if (isPreviousChange) {
+        newMonthYear = this.getPreviousMonth(monthLocal, yearLocal, years);
+      }
+
+      if (isNextChange) {
+        newMonthYear = this.getNextMonth(monthLocal, yearLocal, years);
+      }
+
+      this.setState({
+        year: newMonthYear.yearLocal,
+        month: newMonthYear.monthLocal
+      });
+    }
+  }, {
+    key: "getPreviousMonth",
+    value: function getPreviousMonth(monthLocal, yearLocal, years) {
+      var isStartOfMonth = monthLocal === 0;
+      var isFirstYear = parseInt(yearLocal) === years[0];
+
+      if (!(isStartOfMonth && isFirstYear)) {
+        if (monthLocal === 0) {
+          monthLocal = 11;
+          yearLocal -= 1;
+        } else {
+          monthLocal -= 1;
+        }
+      }
+
+      return {
+        monthLocal: monthLocal,
+        yearLocal: yearLocal
+      };
+    }
+  }, {
+    key: "getNextMonth",
+    value: function getNextMonth(monthLocal, yearLocal, years) {
+      var isEndOfMonth = monthLocal === 11;
+      var isLastYear = parseInt(yearLocal) === years[years.length - 1];
+
+      if (!(isEndOfMonth && isLastYear)) {
+        if (monthLocal === 11) {
+          monthLocal = 0;
+          yearLocal += 1;
+        } else {
+          monthLocal += 1;
+        }
+      }
+
+      return {
+        monthLocal: monthLocal,
+        yearLocal: yearLocal
+      };
+    }
+  }, {
+    key: "changeYearCallback",
+    value: function changeYearCallback(event) {
+      this.setState({
+        year: parseInt(event.target.value)
+      });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var months = this.createMonths(this.props.local);
+      var years = (0, _YearUtils.createYears)(this.props.years, this.props.descendingYears);
+      var headers = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+      var sundayFirst = false;
+
+      if (this.props.local) {
+        if (this.props.local.days) {
+          headers = this.props.local.days;
+        }
+
+        if (this.props.local.sundayFirst) {
+          sundayFirst = true;
+          headers.unshift(headers.pop());
+        }
+      }
+
+      var fourtyTwoDays = (0, _TimeFunctionUtils.getFourtyTwoDays)(this.state.month, this.state.year, sundayFirst);
+      return _react.default.createElement("div", null, _react.default.createElement(_MonthYearSelector.default, {
+        months: months,
+        years: years,
+        month: this.state.month,
+        year: this.state.year,
+        mode: this.props.mode,
+        changeMonthCallback: this.changeMonthCallback,
+        changeYearCallback: this.changeYearCallback,
+        changeMonthArrowsCallback: this.changeMonthArrowsCallback,
+        darkMode: this.props.darkMode
+      }), _react.default.createElement(_CalendarHeader.default, {
+        headers: headers
+      }), _react.default.createElement(_CalendarRows.default, {
+        fourtyTwoDays: fourtyTwoDays,
+        date: this.props.date,
+        mode: this.props.mode,
+        otherDate: this.props.otherDate,
+        maxDate: this.props.maxDate,
+        month: this.state.month,
+        year: this.state.year,
+        dateSelectedNoTimeCallback: this.props.dateSelectedNoTimeCallback,
+        keyboardCellCallback: this.props.keyboardCellCallback,
+        focusOnCallback: this.props.focusOnCallback,
+        focusDate: this.props.focusDate,
+        cellFocusedCallback: this.props.cellFocusedCallback,
+        smartMode: this.props.smartMode,
+        style: this.props.style,
+        darkMode: this.props.darkMode
+      }));
+    }
+  }]);
+
+  return Calendar;
+}(_react.default.Component);
+
+Calendar.propTypes = {
+  date: _reactMomentProptypes.default.momentObj,
+  mode: _propTypes.default.string.isRequired,
+  otherDate: _reactMomentProptypes.default.momentObj,
+  maxDate: _reactMomentProptypes.default.momentObj,
+  dateSelectedNoTimeCallback: _propTypes.default.func.isRequired,
+  keyboardCellCallback: _propTypes.default.func.isRequired,
+  focusOnCallback: _propTypes.default.func.isRequired,
+  focusDate: _propTypes.default.any.isRequired,
+  descendingYears: _propTypes.default.bool,
+  years: _propTypes.default.array,
+  pastSearchFriendly: _propTypes.default.bool,
+  smartMode: _propTypes.default.bool,
+  cellFocusedCallback: _propTypes.default.func.isRequired,
+  local: _propTypes.default.object,
+  style: _propTypes.default.object,
+  darkMode: _propTypes.default.bool
+};
+var _default = Calendar;
+exports.default = _default;

--- a/dist/calendar/CalendarHeader.js
+++ b/dist/calendar/CalendarHeader.js
@@ -1,0 +1,71 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _CssClassNameHelper = require("../utils/CssClassNameHelper");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var CalendarHeader =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(CalendarHeader, _React$Component);
+
+  function CalendarHeader() {
+    _classCallCheck(this, CalendarHeader);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(CalendarHeader).apply(this, arguments));
+  }
+
+  _createClass(CalendarHeader, [{
+    key: "mapHeaderToDiv",
+    value: function mapHeaderToDiv(headers) {
+      var className = (0, _CssClassNameHelper.getCalendarGridHeaderClassName)();
+      return headers.map(function (header, i) {
+        return _react.default.createElement("div", {
+          key: i,
+          className: className
+        }, header);
+      });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var headerDivs = this.mapHeaderToDiv(this.props.headers);
+      var className = (0, _CssClassNameHelper.getCalendarGridClassName)();
+      return _react.default.createElement("div", {
+        className: className
+      }, headerDivs);
+    }
+  }]);
+
+  return CalendarHeader;
+}(_react.default.Component);
+
+var _default = CalendarHeader;
+exports.default = _default;

--- a/dist/calendar/CalendarRow.js
+++ b/dist/calendar/CalendarRow.js
@@ -1,0 +1,115 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _reactMomentProptypes = _interopRequireDefault(require("react-moment-proptypes"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _Cell = _interopRequireDefault(require("./Cell"));
+
+var _CssClassNameHelper = require("../utils/CssClassNameHelper");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var CalendarRow =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(CalendarRow, _React$Component);
+
+  function CalendarRow() {
+    _classCallCheck(this, CalendarRow);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(CalendarRow).apply(this, arguments));
+  }
+
+  _createClass(CalendarRow, [{
+    key: "generateCells",
+    value: function generateCells() {
+      var cells = [];
+      var daysSize = this.props.rowDays.length;
+
+      for (var i = 0; i < daysSize; i++) {
+        cells.push(_react.default.createElement(_Cell.default, {
+          key: i,
+          id: i,
+          row: this.props.row,
+          cellDay: this.props.rowDays[i],
+          date: this.props.date,
+          otherDate: this.props.otherDate,
+          maxDate: this.props.maxDate,
+          month: this.props.month,
+          year: this.props.year,
+          dateSelectedNoTimeCallback: this.props.dateSelectedNoTimeCallback,
+          keyboardCellCallback: this.props.keyboardCellCallback,
+          focusOnCallback: this.props.focusOnCallback,
+          focusDate: this.props.focusDate,
+          cellFocusedCallback: this.props.cellFocusedCallback,
+          mode: this.props.mode,
+          smartMode: this.props.smartMode,
+          style: this.props.style,
+          darkMode: this.props.darkMode
+        }));
+      }
+
+      return cells;
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var cells = this.generateCells();
+      var className = (0, _CssClassNameHelper.getCalendarGridClassName)();
+      return _react.default.createElement("div", {
+        className: className
+      }, cells);
+    }
+  }]);
+
+  return CalendarRow;
+}(_react.default.Component);
+
+CalendarRow.propTypes = {
+  row: _propTypes.default.number.isRequired,
+  rowDays: _propTypes.default.array.isRequired,
+  date: _reactMomentProptypes.default.momentObj.isRequired,
+  otherDate: _reactMomentProptypes.default.momentObj,
+  maxDate: _reactMomentProptypes.default.momentObj,
+  dateSelectedNoTimeCallback: _propTypes.default.func.isRequired,
+  keyboardCellCallback: _propTypes.default.func.isRequired,
+  focusOnCallback: _propTypes.default.func.isRequired,
+  focusDate: _propTypes.default.any.isRequired,
+  year: _propTypes.default.number.isRequired,
+  month: _propTypes.default.number.isRequired,
+  cellFocusedCallback: _propTypes.default.func.isRequired,
+  mode: _propTypes.default.string.isRequired,
+  smartMode: _propTypes.default.bool,
+  style: _propTypes.default.object,
+  darkMode: _propTypes.default.bool
+};
+var _default = CalendarRow;
+exports.default = _default;

--- a/dist/calendar/CalendarRows.js
+++ b/dist/calendar/CalendarRows.js
@@ -1,0 +1,110 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _reactMomentProptypes = _interopRequireDefault(require("react-moment-proptypes"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _CalendarRow = _interopRequireDefault(require("./CalendarRow"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var CalendarRows =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(CalendarRows, _React$Component);
+
+  function CalendarRows() {
+    _classCallCheck(this, CalendarRows);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(CalendarRows).apply(this, arguments));
+  }
+
+  _createClass(CalendarRows, [{
+    key: "generateDays",
+    value: function generateDays() {
+      var calendarRows = [];
+
+      for (var i = 0; i < 6; i++) {
+        var startIndex = i * 7;
+        var endIndex = (i + 1) * 7;
+        var rowDays = this.props.fourtyTwoDays.slice(startIndex, endIndex);
+        calendarRows.push(_react.default.createElement(_CalendarRow.default, {
+          key: i,
+          row: i,
+          rowDays: rowDays,
+          date: this.props.date,
+          otherDate: this.props.otherDate,
+          maxDate: this.props.maxDate,
+          month: this.props.month,
+          year: this.props.year,
+          dateSelectedNoTimeCallback: this.props.dateSelectedNoTimeCallback,
+          keyboardCellCallback: this.props.keyboardCellCallback,
+          focusOnCallback: this.props.focusOnCallback,
+          focusDate: this.props.focusDate,
+          cellFocusedCallback: this.props.cellFocusedCallback,
+          mode: this.props.mode,
+          smartMode: this.props.smartMode,
+          style: this.props.style,
+          darkMode: this.props.darkMode
+        }));
+      }
+
+      return calendarRows;
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var calendarRows = this.generateDays();
+      return _react.default.createElement("div", null, calendarRows);
+    }
+  }]);
+
+  return CalendarRows;
+}(_react.default.Component);
+
+CalendarRows.propTypes = {
+  date: _reactMomentProptypes.default.momentObj,
+  fourtyTwoDays: _propTypes.default.array.isRequired,
+  otherDate: _reactMomentProptypes.default.momentObj,
+  maxDate: _reactMomentProptypes.default.momentObj,
+  dateSelectedNoTimeCallback: _propTypes.default.func.isRequired,
+  keyboardCellCallback: _propTypes.default.func.isRequired,
+  focusOnCallback: _propTypes.default.func.isRequired,
+  focusDate: _propTypes.default.any.isRequired,
+  cellFocusedCallback: _propTypes.default.func.isRequired,
+  year: _propTypes.default.number.isRequired,
+  month: _propTypes.default.number.isRequired,
+  mode: _propTypes.default.string.isRequired,
+  smartMode: _propTypes.default.bool,
+  style: _propTypes.default.object,
+  darkMode: _propTypes.default.bool
+};
+var _default = CalendarRows;
+exports.default = _default;

--- a/dist/calendar/Cell.js
+++ b/dist/calendar/Cell.js
@@ -1,0 +1,409 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _reactDom = _interopRequireDefault(require("react-dom"));
+
+require("../style/DateTimeRange.css");
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _reactMomentProptypes = _interopRequireDefault(require("react-moment-proptypes"));
+
+var _TimeFunctionUtils = require("../utils/TimeFunctionUtils");
+
+var _StyleUtils = require("../utils/StyleUtils");
+
+var _DateSelectedUtils = require("../utils/DateSelectedUtils");
+
+var _CssClassNameHelper = require("../utils/CssClassNameHelper");
+
+var _DateTimeRangePicker = require("../DateTimeRangePicker");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var Cell =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(Cell, _React$Component);
+
+  function Cell(props) {
+    var _this;
+
+    _classCallCheck(this, Cell);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(Cell).call(this, props));
+    _this.state = {
+      style: {}
+    };
+    _this.mouseEnter = _this.mouseEnter.bind(_assertThisInitialized(_this));
+    _this.mouseLeave = _this.mouseLeave.bind(_assertThisInitialized(_this));
+    _this.onClick = _this.onClick.bind(_assertThisInitialized(_this));
+    _this.keyDown = _this.keyDown.bind(_assertThisInitialized(_this));
+    _this.onFocus = _this.onFocus.bind(_assertThisInitialized(_this));
+    _this.onBlur = _this.onBlur.bind(_assertThisInitialized(_this));
+    return _this;
+  }
+
+  _createClass(Cell, [{
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(oldProps) {
+      if (!this.props.date.isSame(oldProps.date) || !this.props.otherDate.isSame(oldProps.otherDate)) {
+        this.styleCellNonMouseEnter();
+      }
+
+      if (!this.props.cellDay.isSame(oldProps.cellDay)) {
+        this.styleCellNonMouseEnter();
+      } // If a Cell is Selected
+      // If the focusDate is this cell
+      // and its not a gray cell
+      // Then Focus on this cell
+
+
+      var cellFocused = false;
+      var focusDateIsCellDate = _typeof(this.props.focusDate) === 'object' && this.props.focusDate.isSame(this.props.cellDay, 'day');
+      var activeElement = document.activeElement.id;
+
+      if (activeElement && activeElement.indexOf('_cell_') !== -1) {
+        cellFocused = true;
+      }
+
+      if (cellFocused && focusDateIsCellDate && !this.isCellMonthSameAsPropMonth(this.props.cellDay)) {
+        this.cell.focus();
+        this.props.focusOnCallback(false);
+      }
+    }
+  }, {
+    key: "pastMaxDatePropsChecker",
+    value: function pastMaxDatePropsChecker(isCellDateProp, days) {
+      if (isCellDateProp) {
+        if ((0, _DateSelectedUtils.pastMaxDate)((0, _moment.default)(this.props.date).add(days, 'days'), this.props.maxDate, true)) {
+          return true;
+        }
+      } else {
+        if ((0, _DateSelectedUtils.pastMaxDate)((0, _moment.default)(this.props.otherDate).add(days, 'days'), this.props.maxDate, true)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  }, {
+    key: "keyDown",
+    value: function keyDown(e) {
+      var componentFocused = document.activeElement === _reactDom.default.findDOMNode(this.cell);
+
+      if (componentFocused && e.keyCode >= 37 && e.keyCode <= 40) {
+        e.preventDefault();
+        var newDate = (0, _moment.default)(this.props.cellDay); // Check to see if this cell is the date prop
+
+        var isCellDateProp = this.props.cellDay.isSame(this.props.date, 'day');
+
+        if (e.keyCode === 38) {
+          // Up Key
+          newDate.subtract(7, 'days');
+        } else if (e.keyCode === 40) {
+          // Down Key
+          if (this.pastMaxDatePropsChecker(isCellDateProp, 7)) {
+            return;
+          }
+
+          newDate.add(7, 'days');
+        } else if (e.keyCode === 37) {
+          // Left Key
+          newDate.subtract(1, 'days');
+        } else if (e.keyCode === 39) {
+          // Right Key
+          if (this.pastMaxDatePropsChecker(isCellDateProp, 1)) {
+            return;
+          }
+
+          newDate.add(1, 'days');
+        }
+
+        var isSuccessfulCallback = this.props.keyboardCellCallback(this.props.cellDay, newDate);
+
+        if (isSuccessfulCallback) {
+          this.props.focusOnCallback(newDate);
+        }
+      }
+    }
+  }, {
+    key: "onClick",
+    value: function onClick() {
+      if ((0, _DateSelectedUtils.pastMaxDate)(this.props.cellDay, this.props.maxDate, false)) {
+        return;
+      }
+
+      this.props.dateSelectedNoTimeCallback(this.props.cellDay, this.props.mode);
+    }
+  }, {
+    key: "mouseEnter",
+    value: function mouseEnter() {
+      // If Past Max Date Style Cell Out of Use
+      if (this.checkAndSetMaxDateStyle(this.props.cellDay)) {
+        return;
+      } // If smart mode disabled check cell dates to ensure not past end in start mode and not before start in end mode
+
+
+      if (!this.props.smartMode && this.nonSmartModePastStartAndEndChecks(this.props.cellDay)) {
+        return;
+      } // Custom hover cell styling
+
+
+      if (this.props.style && this.props.style.hoverCell) {
+        var style = Object.assign((0, _TimeFunctionUtils.hoverCellStyle)(false, this.props.darkMode), this.props.style.hoverCell);
+        return this.setState({
+          style: style
+        });
+      } // Hover Style Cell, Different if inbetween start and end date
+
+
+      var isDateStart = this.props.date.isSameOrBefore(this.props.otherDate, 'second');
+
+      if ((0, _TimeFunctionUtils.isInbetweenDates)(isDateStart, this.props.cellDay, this.props.date, this.props.otherDate)) {
+        this.setState({
+          style: (0, _TimeFunctionUtils.hoverCellStyle)(true, this.props.darkMode)
+        });
+      } else {
+        this.setState({
+          style: (0, _TimeFunctionUtils.hoverCellStyle)(false, this.props.darkMode)
+        });
+      }
+    }
+  }, {
+    key: "mouseLeave",
+    value: function mouseLeave() {
+      this.styleCellNonMouseEnter();
+    }
+  }, {
+    key: "onFocus",
+    value: function onFocus() {
+      this.props.cellFocusedCallback(this.props.cellDay);
+      this.setState({
+        focus: true
+      });
+    }
+  }, {
+    key: "onBlur",
+    value: function onBlur() {
+      this.setState({
+        focus: false
+      });
+    }
+  }, {
+    key: "isCellMonthSameAsPropMonth",
+    value: function isCellMonthSameAsPropMonth(cellDay) {
+      var month = this.props.month;
+      var cellDayMonth = cellDay.month();
+
+      if (month !== cellDayMonth) {
+        return true;
+      }
+    }
+  }, {
+    key: "shouldStyleCellStartEnd",
+    value: function shouldStyleCellStartEnd(cellDay, date, otherDate, startCheck, endCheck) {
+      var isCellDateProp = cellDay.isSame(date, 'day');
+      var isCellOtherDateProp = cellDay.isSame(otherDate, 'day');
+      var isDateStart = date.isSameOrBefore(otherDate, 'second');
+      var isOtherDateStart = otherDate.isSameOrBefore(date, 'second');
+
+      if (startCheck) {
+        return isCellDateProp && isDateStart || isCellOtherDateProp && isOtherDateStart;
+      } else if (endCheck) {
+        return isCellDateProp && !isDateStart || isCellOtherDateProp && !isOtherDateStart;
+      }
+    }
+  }, {
+    key: "checkAndSetMaxDateStyle",
+    value: function checkAndSetMaxDateStyle(cellDate) {
+      // If Past Max Date Style Cell Out of Use
+      if ((0, _DateSelectedUtils.pastMaxDate)(cellDate, this.props.maxDate, false)) {
+        this.setState({
+          style: (0, _TimeFunctionUtils.invalidStyle)(this.props.darkMode)
+        });
+        return true;
+      }
+
+      return false;
+    }
+  }, {
+    key: "nonSmartModePastStartAndEndChecks",
+    value: function nonSmartModePastStartAndEndChecks(cellDate) {
+      // If in start mode and cellDate past end date style as unavailable. If in end mode and cellDate before start date style as unavailable
+      if (this.props.mode === _DateTimeRangePicker.ModeEnum.start) {
+        // We know now the date prop is the start date and the otherDate is the end date in non smart mode
+        // If this cell is after end date then invalid cell as this is the start mode
+        if (cellDate.isAfter(this.props.otherDate, 'day')) {
+          this.setState({
+            style: (0, _TimeFunctionUtils.invalidStyle)(this.props.darkMode)
+          });
+          return true;
+        }
+      } else if (this.props.mode === _DateTimeRangePicker.ModeEnum.end) {
+        // We know now the date prop is the end date and the otherDate is the start date in non smart mode
+        // If this cell is before start date then invalid cell as this is the end mode
+        if (cellDate.isBefore(this.props.otherDate, 'day')) {
+          this.setState({
+            style: (0, _TimeFunctionUtils.invalidStyle)(this.props.darkMode)
+          });
+          return true;
+        }
+      }
+
+      return false;
+    }
+  }, {
+    key: "styleCellNonMouseEnter",
+    value: function styleCellNonMouseEnter() {
+      var cellDay = this.props.cellDay;
+      var date = this.props.date;
+      var otherDate = this.props.otherDate; // If Past Max Date Style Cell Out of Use
+
+      if (this.checkAndSetMaxDateStyle(cellDay)) {
+        return;
+      } // If smart mode disabled check cell dates to ensure not past end in start mode and not before start in end mode
+
+
+      if (!this.props.smartMode && this.nonSmartModePastStartAndEndChecks(cellDay)) {
+        return;
+      } // Anything cellDay month that is before or after the cell prop month style grey
+
+
+      if (this.isCellMonthSameAsPropMonth(cellDay)) {
+        this.setState({
+          style: (0, _TimeFunctionUtils.greyCellStyle)(this.props.darkMode)
+        });
+        return;
+      }
+
+      var isDateStart = date.isSameOrBefore(otherDate, 'second');
+      var inbetweenDates = (0, _TimeFunctionUtils.isInbetweenDates)(isDateStart, cellDay, date, otherDate);
+      var isStart = this.shouldStyleCellStartEnd(cellDay, date, otherDate, true, false);
+      var isEnd = this.shouldStyleCellStartEnd(cellDay, date, otherDate, false, true); // If start, end or inbetween date then style according to user input or use default
+
+      if (isStart || isEnd || inbetweenDates) {
+        var style;
+
+        if (isStart && this.props.style && this.props.style.fromDate) {
+          style = Object.assign((0, _TimeFunctionUtils.startDateStyle)(), this.props.style.fromDate);
+        } else if (isStart) {
+          style = (0, _TimeFunctionUtils.startDateStyle)();
+        } else if (isEnd && this.props.style && this.props.style.toDate) {
+          style = Object.assign((0, _TimeFunctionUtils.endDateStyle)(), this.props.style.toDate);
+        } else if (isEnd) {
+          style = (0, _TimeFunctionUtils.endDateStyle)();
+        } else if (inbetweenDates && this.props.style && this.props.style.betweenDates) {
+          style = Object.assign((0, _TimeFunctionUtils.inBetweenStyle)(), this.props.style.betweenDates);
+        } else {
+          style = (0, _TimeFunctionUtils.inBetweenStyle)();
+        }
+
+        this.setState({
+          style: style
+        });
+      } else if (inbetweenDates) {
+        this.setState({
+          style: (0, _TimeFunctionUtils.inBetweenStyle)()
+        });
+      } else {
+        this.setState({
+          style: (0, _TimeFunctionUtils.normalCellStyle)(this.props.darkMode)
+        });
+      }
+    }
+  }, {
+    key: "isStartOrEndDate",
+    value: function isStartOrEndDate() {
+      var cellDay = this.props.cellDay;
+      var date = this.props.date;
+      var otherDate = this.props.otherDate;
+
+      if (this.shouldStyleCellStartEnd(cellDay, date, otherDate, true, false) || this.shouldStyleCellStartEnd(cellDay, date, otherDate, false, true)) {
+        return true;
+      }
+
+      return false;
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
+
+      var className = (0, _CssClassNameHelper.getCalendarGridCellClassName)();
+      var dateFormatted = this.props.cellDay.format('D');
+      var tabIndex = -1;
+
+      if (this.isStartOrEndDate() && !this.isCellMonthSameAsPropMonth(this.props.cellDay)) {
+        document.addEventListener('keydown', this.keyDown, false);
+        tabIndex = 0;
+      } else {
+        document.removeEventListener('keydown', this.keyDown, false);
+      }
+
+      var style = (0, _StyleUtils.addFocusStyle)(this.state.focus, this.state.style);
+      return _react.default.createElement("div", {
+        ref: function ref(cell) {
+          _this2.cell = cell;
+        },
+        className: className,
+        tabIndex: tabIndex,
+        style: style,
+        onMouseEnter: this.mouseEnter,
+        onMouseLeave: this.mouseLeave,
+        onClick: this.onClick,
+        onFocus: this.onFocus,
+        onBlur: this.onBlur,
+        id: "row_".concat(this.props.row, "_cell_").concat(this.props.id, "_").concat(this.props.mode)
+      }, dateFormatted);
+    }
+  }]);
+
+  return Cell;
+}(_react.default.Component);
+
+Cell.propTypes = {
+  id: _propTypes.default.number.isRequired,
+  cellDay: _reactMomentProptypes.default.momentObj.isRequired,
+  date: _reactMomentProptypes.default.momentObj.isRequired,
+  otherDate: _reactMomentProptypes.default.momentObj,
+  maxDate: _reactMomentProptypes.default.momentObj,
+  dateSelectedNoTimeCallback: _propTypes.default.func.isRequired,
+  keyboardCellCallback: _propTypes.default.func.isRequired,
+  focusOnCallback: _propTypes.default.func.isRequired,
+  focusDate: _propTypes.default.any.isRequired,
+  month: _propTypes.default.number.isRequired,
+  cellFocusedCallback: _propTypes.default.func.isRequired,
+  mode: _propTypes.default.string.isRequired,
+  smartMode: _propTypes.default.bool,
+  style: _propTypes.default.object,
+  darkMode: _propTypes.default.bool
+};
+var _default = Cell;
+exports.default = _default;

--- a/dist/calendar/MonthYearSelector.js
+++ b/dist/calendar/MonthYearSelector.js
@@ -1,0 +1,176 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _reactBootstrap = require("react-bootstrap");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _StyleUtils = require("../utils/StyleUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var MonthYearSelector =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(MonthYearSelector, _React$Component);
+
+  function MonthYearSelector(props) {
+    var _this;
+
+    _classCallCheck(this, MonthYearSelector);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(MonthYearSelector).call(this, props));
+    _this.state = {
+      monthFocus: false,
+      yearFocus: false
+    };
+    _this.monthFocus = _this.monthFocus.bind(_assertThisInitialized(_this));
+    _this.yearFocus = _this.yearFocus.bind(_assertThisInitialized(_this));
+    _this.monthBlur = _this.monthBlur.bind(_assertThisInitialized(_this));
+    _this.yearBlur = _this.yearBlur.bind(_assertThisInitialized(_this));
+    return _this;
+  }
+
+  _createClass(MonthYearSelector, [{
+    key: "createCalendarMonths",
+    value: function createCalendarMonths(months) {
+      return this.mapToOption(months);
+    }
+  }, {
+    key: "createYears",
+    value: function createYears(years) {
+      return this.mapToOption(years);
+    }
+  }, {
+    key: "monthFocus",
+    value: function monthFocus() {
+      this.setState({
+        monthFocus: true
+      });
+    }
+  }, {
+    key: "monthBlur",
+    value: function monthBlur() {
+      this.setState({
+        monthFocus: false
+      });
+    }
+  }, {
+    key: "yearFocus",
+    value: function yearFocus() {
+      this.setState({
+        yearFocus: true
+      });
+    }
+  }, {
+    key: "yearBlur",
+    value: function yearBlur() {
+      this.setState({
+        yearFocus: false
+      });
+    }
+  }, {
+    key: "mapToOption",
+    value: function mapToOption(variableArray) {
+      return variableArray.map(function (varInstance, i) {
+        return _react.default.createElement("option", {
+          key: i
+        }, varInstance);
+      });
+    }
+  }, {
+    key: "createGlyph",
+    value: function createGlyph(icon, onClickHandler, previous, next) {
+      return _react.default.createElement(_reactBootstrap.Glyphicon, {
+        glyph: icon,
+        style: {
+          cursor: 'pointer'
+        },
+        onClick: function onClick() {
+          return onClickHandler(previous, next);
+        }
+      });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var months = this.createCalendarMonths(this.props.months);
+      var years = this.createYears(this.props.years);
+      var theme = this.props.darkMode ? _StyleUtils.darkTheme : _StyleUtils.lightTheme;
+      var leftArrow = this.createGlyph('chevron-left', this.props.changeMonthArrowsCallback, true, false);
+      var rightArrow = this.createGlyph('chevron-right', this.props.changeMonthArrowsCallback, false, true);
+      var monthFocusStyle = {};
+      monthFocusStyle = (0, _StyleUtils.addFocusStyle)(this.state.monthFocus, monthFocusStyle);
+      var yearFocusStyle = {};
+      yearFocusStyle = (0, _StyleUtils.addFocusStyle)(this.state.yearFocus, yearFocusStyle);
+      return _react.default.createElement("div", {
+        className: "monthYearContainer"
+      }, _react.default.createElement("div", {
+        className: "multipleContentOnLine leftChevron"
+      }, leftArrow), _react.default.createElement("div", {
+        className: "multipleContentOnLine",
+        onFocus: this.monthFocus,
+        onBlur: this.monthBlur,
+        style: monthFocusStyle
+      }, _react.default.createElement("select", {
+        id: 'MonthSelector_' + this.props.mode,
+        value: this.props.months[this.props.month],
+        onChange: this.props.changeMonthCallback,
+        style: theme
+      }, months)), _react.default.createElement("div", {
+        className: "multipleContentOnLine",
+        onFocus: this.yearFocus,
+        onBlur: this.yearBlur,
+        style: yearFocusStyle
+      }, _react.default.createElement("select", {
+        id: 'YearSelector_' + this.props.mode,
+        value: this.props.year,
+        onChange: this.props.changeYearCallback,
+        style: theme
+      }, years)), _react.default.createElement("div", {
+        className: "multipleContentOnLine rightChevron"
+      }, rightArrow));
+    }
+  }]);
+
+  return MonthYearSelector;
+}(_react.default.Component);
+
+MonthYearSelector.propTypes = {
+  months: _propTypes.default.array.isRequired,
+  years: _propTypes.default.array.isRequired,
+  month: _propTypes.default.number.isRequired,
+  year: _propTypes.default.number.isRequired,
+  changeMonthCallback: _propTypes.default.func.isRequired,
+  changeYearCallback: _propTypes.default.func.isRequired,
+  changeMonthArrowsCallback: _propTypes.default.func.isRequired,
+  darkMode: _propTypes.default.bool
+};
+var _default = MonthYearSelector;
+exports.default = _default;

--- a/dist/date_picker/ActiveNotifier.js
+++ b/dist/date_picker/ActiveNotifier.js
@@ -1,0 +1,107 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var ActiveNotifier =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(ActiveNotifier, _React$Component);
+
+  function ActiveNotifier() {
+    _classCallCheck(this, ActiveNotifier);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(ActiveNotifier).apply(this, arguments));
+  }
+
+  _createClass(ActiveNotifier, [{
+    key: "getDotDiv",
+    value: function getDotDiv(text, style, id) {
+      return _react.default.createElement("div", {
+        className: "activeNotifier",
+        id: id
+      }, text, " ", _react.default.createElement("span", {
+        className: "dot",
+        style: style
+      }));
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var selectingModeFrom = this.props.selectingModeFrom;
+      var mode = this.props.mode;
+      var startDotStyle = this.props.style && this.props.style.fromDot ? this.props.style.fromDot : {
+        backgroundColor: '#12bc00'
+      };
+      var endDotStyle = this.props.style && this.props.style.toDot ? this.props.style.toDot : {
+        backgroundColor: '#D70022'
+      };
+      var startNotifierID = 'startNotifierID';
+      var endNotifierID = 'endNotifierID';
+      var local = this.props.local;
+
+      if (this.props.smartMode) {
+        if (selectingModeFrom && mode === 'start') {
+          var label = local && local.selectingFrom ? local.selectingFrom : 'Selecting From';
+          return this.getDotDiv("".concat(label, " "), startDotStyle, startNotifierID);
+        } else if (!selectingModeFrom && mode === 'end') {
+          var _label = local && local.selectingTo ? local.selectingTo : 'Selecting To';
+
+          return this.getDotDiv("".concat(_label, " "), endDotStyle, endNotifierID);
+        }
+      } else {
+        if (mode === 'start') {
+          var _label2 = local && local.fromDate ? local.fromDate : 'From Date';
+
+          return this.getDotDiv("".concat(_label2, " "), startDotStyle, startNotifierID);
+        } else if (mode === 'end') {
+          var _label3 = local && local.toDate ? local.toDate : 'To Date';
+
+          return this.getDotDiv("".concat(_label3, " "), endDotStyle, endNotifierID);
+        }
+      }
+
+      return _react.default.createElement("div", null);
+    }
+  }]);
+
+  return ActiveNotifier;
+}(_react.default.Component);
+
+ActiveNotifier.propTypes = {
+  mode: _propTypes.default.string.isRequired,
+  selectingModeFrom: _propTypes.default.bool.isRequired,
+  smartMode: _propTypes.default.bool,
+  style: _propTypes.default.object,
+  local: _propTypes.default.object
+};
+var _default = ActiveNotifier;
+exports.default = _default;

--- a/dist/date_picker/ApplyCancelButtons.js
+++ b/dist/date_picker/ApplyCancelButtons.js
@@ -1,0 +1,254 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _reactMomentProptypes = _interopRequireDefault(require("react-moment-proptypes"));
+
+var _reactDotFragment = _interopRequireDefault(require("react-dot-fragment"));
+
+var _StyleUtils = require("../utils/StyleUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var ApplyCancelButtons =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(ApplyCancelButtons, _React$Component);
+
+  function ApplyCancelButtons(props) {
+    var _this;
+
+    _classCallCheck(this, ApplyCancelButtons);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(ApplyCancelButtons).call(this, props));
+    _this.state = {
+      hoverColourApply: '#5cb85c',
+      hoverColourCancel: '#fff',
+      applyFocus: false,
+      cancelFocus: false
+    };
+
+    _this.bindToFunctions();
+
+    return _this;
+  }
+
+  _createClass(ApplyCancelButtons, [{
+    key: "bindToFunctions",
+    value: function bindToFunctions() {
+      this.mouseEnterApply = this.mouseEnterApply.bind(this);
+      this.mouseLeaveApply = this.mouseLeaveApply.bind(this);
+      this.mouseEnterCancel = this.mouseEnterCancel.bind(this);
+      this.mouseLeaveCancel = this.mouseLeaveCancel.bind(this);
+      this.cancelPressed = this.cancelPressed.bind(this);
+      this.applyPressed = this.applyPressed.bind(this);
+      this.applyOnKeyPress = this.applyOnKeyPress.bind(this);
+      this.cancelOnKeyPress = this.cancelOnKeyPress.bind(this);
+      this.applyOnFocus = this.applyOnFocus.bind(this);
+      this.applyOnBlur = this.applyOnBlur.bind(this);
+      this.cancelOnBlur = this.cancelOnBlur.bind(this);
+      this.cancelOnFocus = this.cancelOnFocus.bind(this);
+    }
+  }, {
+    key: "mouseEnterApply",
+    value: function mouseEnterApply() {
+      this.setState({
+        hoverColourApply: '#3e8e41'
+      });
+    }
+  }, {
+    key: "mouseLeaveApply",
+    value: function mouseLeaveApply() {
+      this.setState({
+        hoverColourApply: '#5cb85c'
+      });
+    }
+  }, {
+    key: "mouseEnterCancel",
+    value: function mouseEnterCancel() {
+      this.setState({
+        hoverColourCancel: 'rgb(192, 185, 185)'
+      });
+    }
+  }, {
+    key: "mouseLeaveCancel",
+    value: function mouseLeaveCancel() {
+      this.setState({
+        hoverColourCancel: '#fff'
+      });
+    }
+  }, {
+    key: "cancelPressed",
+    value: function cancelPressed() {
+      this.props.changeVisibleState();
+    }
+  }, {
+    key: "applyPressed",
+    value: function applyPressed() {
+      this.props.applyCallback();
+    }
+  }, {
+    key: "applyOnFocus",
+    value: function applyOnFocus() {
+      this.setState({
+        applyFocus: true
+      });
+    }
+  }, {
+    key: "applyOnBlur",
+    value: function applyOnBlur() {
+      this.setState({
+        applyFocus: false
+      });
+    }
+  }, {
+    key: "cancelOnFocus",
+    value: function cancelOnFocus() {
+      this.setState({
+        cancelFocus: true
+      });
+    }
+  }, {
+    key: "cancelOnBlur",
+    value: function cancelOnBlur() {
+      this.setState({
+        cancelFocus: false
+      });
+    }
+  }, {
+    key: "isSpaceBarOrEnterPressed",
+    value: function isSpaceBarOrEnterPressed(e) {
+      if (e.keyCode === 32 || e.keyCode === 13) {
+        return true;
+      }
+
+      return false;
+    }
+  }, {
+    key: "applyOnKeyPress",
+    value: function applyOnKeyPress(e) {
+      if (this.isSpaceBarOrEnterPressed(e)) {
+        this.props.applyCallback();
+      }
+    }
+  }, {
+    key: "cancelOnKeyPress",
+    value: function cancelOnKeyPress(e) {
+      if (this.isSpaceBarOrEnterPressed(e)) {
+        this.props.changeVisibleState();
+      }
+    }
+  }, {
+    key: "renderButton",
+    value: function renderButton(className, onMouseEnter, onMouseLeave, onClick, style, onKeyDown, onFocus, onBlur, text) {
+      var styleLocal;
+
+      if (text === 'Apply') {
+        styleLocal = (0, _StyleUtils.addFocusStyle)(this.state.applyFocus, style);
+      } else {
+        styleLocal = (0, _StyleUtils.addFocusStyle)(this.state.cancelFocus, style);
+      }
+
+      return _react.default.createElement("div", {
+        className: className,
+        role: "button",
+        onMouseEnter: onMouseEnter,
+        onMouseLeave: onMouseLeave,
+        onClick: onClick,
+        style: styleLocal,
+        onKeyDown: onKeyDown,
+        tabIndex: 0,
+        onFocus: onFocus,
+        onBlur: onBlur
+      }, text);
+    }
+  }, {
+    key: "getMaxDateBox",
+    value: function getMaxDateBox() {
+      if (this.props.maxDate) {
+        var label = this.props.local && this.props.local.maxDate ? this.props.local.maxDate : 'Max Date';
+        return _react.default.createElement("div", {
+          className: "maxDateLabel"
+        }, label, ": ", this.props.maxDate.format(this.props.local.format));
+      }
+    }
+  }, {
+    key: "renderButtons",
+    value: function renderButtons() {
+      var applyButton;
+      var closeButtonText = this.props.local && this.props.local.close ? this.props.local.close : 'Close';
+
+      if (!this.props.autoApply) {
+        applyButton = this.renderButton('buttonSeperator applyButton', this.mouseEnterApply, this.mouseLeaveApply, this.applyPressed, {
+          backgroundColor: this.state.hoverColourApply
+        }, this.applyOnKeyPress, this.applyOnFocus, this.applyOnBlur, this.props.local && this.props.local.apply ? this.props.local.apply : 'Apply');
+        closeButtonText = this.props.local && this.props.local.cancel ? this.props.local.cancel : 'Cancel';
+      }
+
+      var closeButton = this.renderButton('buttonSeperator cancelButton', this.mouseEnterCancel, this.mouseLeaveCancel, this.cancelPressed, {
+        backgroundColor: this.state.hoverColourCancel
+      }, this.cancelOnKeyPress, this.cancelOnFocus, this.cancelOnBlur, closeButtonText);
+      return _react.default.createElement(_reactDotFragment.default, null, applyButton, !this.props.standalone ? closeButton : null);
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var maxDateBox = this.getMaxDateBox();
+      var buttons = this.renderButtons();
+      var style = undefined;
+
+      if (this.props.standalone) {
+        style = {
+          position: 'unset',
+          float: 'right'
+        };
+      }
+
+      return _react.default.createElement("div", {
+        id: "buttonContainer",
+        className: "buttonContainer",
+        style: style
+      }, maxDateBox, buttons);
+    }
+  }]);
+
+  return ApplyCancelButtons;
+}(_react.default.Component);
+
+ApplyCancelButtons.propTypes = {
+  local: _propTypes.default.object,
+  maxDate: _reactMomentProptypes.default.momentObj,
+  applyCallback: _propTypes.default.func.isRequired,
+  changeVisibleState: _propTypes.default.func.isRequired,
+  autoApply: _propTypes.default.bool,
+  standalone: _propTypes.default.bool
+};
+var _default = ApplyCancelButtons;
+exports.default = _default;

--- a/dist/date_picker/DateField.js
+++ b/dist/date_picker/DateField.js
@@ -1,0 +1,115 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _reactBootstrap = require("react-bootstrap");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _StyleUtils = require("../utils/StyleUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var DateField =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(DateField, _React$Component);
+
+  function DateField(props) {
+    var _this;
+
+    _classCallCheck(this, DateField);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(DateField).call(this, props));
+    _this.onChangeDateTextHandler = _this.onChangeDateTextHandler.bind(_assertThisInitialized(_this));
+    _this.onBlur = _this.onBlur.bind(_assertThisInitialized(_this));
+    _this.onClick = _this.onClick.bind(_assertThisInitialized(_this));
+    return _this;
+  }
+
+  _createClass(DateField, [{
+    key: "onChangeDateTextHandler",
+    value: function onChangeDateTextHandler(event) {
+      this.props.onChangeDateTextHandlerCallback(event.target.value, this.props.mode);
+    }
+  }, {
+    key: "onBlur",
+    value: function onBlur() {
+      this.props.dateTextFieldCallback(this.props.mode);
+    }
+  }, {
+    key: "onClick",
+    value: function onClick() {
+      if (this.props.mode === 'start') {
+        this.props.changeSelectingModeCallback(true);
+      } else {
+        this.props.changeSelectingModeCallback(false);
+      }
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var glyphColor = this.props.darkMode ? '#FFFFFF' : '#555';
+      var theme = this.props.darkMode ? _StyleUtils.darkTheme : _StyleUtils.lightTheme;
+      return _react.default.createElement(_reactBootstrap.InputGroup, {
+        onClick: this.onClick,
+        style: {
+          cursor: 'pointer'
+        }
+      }, _react.default.createElement(_reactBootstrap.InputGroup.Addon, {
+        className: "calendarAddon"
+      }, _react.default.createElement(_reactBootstrap.Glyphicon, {
+        style: {
+          color: glyphColor
+        },
+        glyph: "calendar"
+      })), _react.default.createElement(_reactBootstrap.FormControl, {
+        className: "inputDate",
+        id: "DateTimeInput_" + this.props.mode,
+        style: theme,
+        type: "text",
+        value: this.props.dateLabel,
+        onChange: this.onChangeDateTextHandler,
+        onBlur: this.onBlur
+      }));
+    }
+  }]);
+
+  return DateField;
+}(_react.default.Component);
+
+DateField.propTypes = {
+  changeSelectingModeCallback: _propTypes.default.func.isRequired,
+  mode: _propTypes.default.string.isRequired,
+  dateLabel: _propTypes.default.string.isRequired,
+  dateTextFieldCallback: _propTypes.default.func.isRequired,
+  onChangeDateTextHandlerCallback: _propTypes.default.func.isRequired,
+  darkMode: _propTypes.default.bool
+};
+var _default = DateField;
+exports.default = _default;

--- a/dist/date_picker/DatePicker.js
+++ b/dist/date_picker/DatePicker.js
@@ -1,0 +1,158 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _reactMomentProptypes = _interopRequireDefault(require("react-moment-proptypes"));
+
+var _Label = _interopRequireDefault(require("./Label"));
+
+var _DateField = _interopRequireDefault(require("./DateField"));
+
+var _TimeField = _interopRequireDefault(require("./TimeField"));
+
+var _Calendar = _interopRequireDefault(require("../calendar/Calendar"));
+
+var _ApplyCancelButtons = _interopRequireDefault(require("./ApplyCancelButtons"));
+
+var _ActiveNotifier = _interopRequireDefault(require("./ActiveNotifier"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var DatePicker =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(DatePicker, _React$Component);
+
+  function DatePicker() {
+    _classCallCheck(this, DatePicker);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(DatePicker).apply(this, arguments));
+  }
+
+  _createClass(DatePicker, [{
+    key: "render",
+    value: function render() {
+      //If button property present display buttons
+      var buttons;
+
+      if (this.props.enableButtons) {
+        buttons = _react.default.createElement(_ApplyCancelButtons.default, {
+          changeVisibleState: this.props.changeVisibleState,
+          applyCallback: this.props.applyCallback,
+          local: this.props.local,
+          maxDate: this.props.maxDate,
+          autoApply: this.props.autoApply,
+          standalone: this.props.standalone
+        });
+      }
+
+      return _react.default.createElement("div", {
+        className: "fromDateTimeContainer"
+      }, _react.default.createElement("div", {
+        className: "fromDateHourContainer"
+      }, _react.default.createElement(_Label.default, {
+        label: this.props.label
+      }), _react.default.createElement(_DateField.default, {
+        date: (0, _moment.default)(this.props.date),
+        dateTextFieldCallback: this.props.dateTextFieldCallback,
+        onChangeDateTextHandlerCallback: this.props.onChangeDateTextHandlerCallback,
+        dateLabel: this.props.dateLabel,
+        mode: this.props.mode,
+        changeSelectingModeCallback: this.props.changeSelectingModeCallback,
+        darkMode: this.props.darkMode
+      }), _react.default.createElement(_TimeField.default, {
+        date: this.props.date,
+        timeChangeCallback: this.props.timeChangeCallback,
+        mode: this.props.mode,
+        darkMode: this.props.darkMode
+      })), _react.default.createElement(_Calendar.default, {
+        date: this.props.date,
+        mode: this.props.mode,
+        otherDate: this.props.otherDate,
+        maxDate: this.props.maxDate,
+        dateSelectedNoTimeCallback: this.props.dateSelectedNoTimeCallback,
+        keyboardCellCallback: this.props.keyboardCellCallback,
+        focusOnCallback: this.props.focusOnCallback,
+        focusDate: this.props.focusDate,
+        cellFocusedCallback: this.props.cellFocusedCallback,
+        local: this.props.local,
+        descendingYears: this.props.descendingYears,
+        years: this.props.years,
+        pastSearchFriendly: this.props.pastSearchFriendly,
+        smartMode: this.props.smartMode,
+        style: this.props.style,
+        darkMode: this.props.darkMode
+      }), _react.default.createElement(_ActiveNotifier.default, {
+        selectingModeFrom: this.props.selectingModeFrom,
+        mode: this.props.mode,
+        smartMode: this.props.smartMode,
+        style: this.props.style,
+        local: this.props.local
+      }), buttons);
+    }
+  }]);
+
+  return DatePicker;
+}(_react.default.Component);
+
+DatePicker.propTypes = {
+  local: _propTypes.default.object,
+  date: _reactMomentProptypes.default.momentObj.isRequired,
+  otherDate: _reactMomentProptypes.default.momentObj,
+  mode: _propTypes.default.string.isRequired,
+  maxDate: _reactMomentProptypes.default.momentObj,
+  applyCallback: _propTypes.default.func.isRequired,
+  dateSelectedNoTimeCallback: _propTypes.default.func.isRequired,
+  keyboardCellCallback: _propTypes.default.func.isRequired,
+  cellFocusedCallback: _propTypes.default.func.isRequired,
+  focusOnCallback: _propTypes.default.func.isRequired,
+  focusDate: _propTypes.default.any.isRequired,
+  selectingModeFrom: _propTypes.default.bool.isRequired,
+  changeVisibleState: _propTypes.default.func,
+  timeChangeCallback: _propTypes.default.func.isRequired,
+  changeSelectingModeCallback: _propTypes.default.func.isRequired,
+  onChangeDateTextHandlerCallback: _propTypes.default.func.isRequired,
+  dateTextFieldCallback: _propTypes.default.func.isRequired,
+  dateLabel: _propTypes.default.string.isRequired,
+  label: _propTypes.default.string.isRequired,
+  descendingYears: _propTypes.default.bool,
+  years: _propTypes.default.array,
+  pastSearchFriendly: _propTypes.default.bool,
+  smartMode: _propTypes.default.bool,
+  enableButtons: _propTypes.default.bool,
+  autoApply: _propTypes.default.bool,
+  style: _propTypes.default.object,
+  darkMode: _propTypes.default.bool,
+  standalone: _propTypes.default.bool
+};
+var _default = DatePicker;
+exports.default = _default;

--- a/dist/date_picker/Label.js
+++ b/dist/date_picker/Label.js
@@ -1,0 +1,61 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var Label =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(Label, _React$Component);
+
+  function Label() {
+    _classCallCheck(this, Label);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(Label).apply(this, arguments));
+  }
+
+  _createClass(Label, [{
+    key: "render",
+    value: function render() {
+      return _react.default.createElement("div", {
+        className: "dateTimeLabel"
+      }, this.props.label);
+    }
+  }]);
+
+  return Label;
+}(_react.default.Component);
+
+var _default = Label;
+exports.default = _default;
+Label.propTypes = {
+  label: _propTypes.default.string.isRequired
+};

--- a/dist/date_picker/TimeField.js
+++ b/dist/date_picker/TimeField.js
@@ -1,0 +1,193 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _reactBootstrap = require("react-bootstrap");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _reactMomentProptypes = _interopRequireDefault(require("react-moment-proptypes"));
+
+var _TimeFunctionUtils = require("../utils/TimeFunctionUtils");
+
+var _StyleUtils = require("../utils/StyleUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var TimeField =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(TimeField, _React$Component);
+
+  function TimeField(props) {
+    var _this;
+
+    _classCallCheck(this, TimeField);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(TimeField).call(this, props));
+    _this.state = {
+      hourFocus: false,
+      minuteFocus: false
+    };
+    _this.handleHourChange = _this.handleHourChange.bind(_assertThisInitialized(_this));
+    _this.handleMinuteChange = _this.handleMinuteChange.bind(_assertThisInitialized(_this));
+    _this.hourFocus = _this.hourFocus.bind(_assertThisInitialized(_this));
+    _this.minuteFocus = _this.minuteFocus.bind(_assertThisInitialized(_this));
+    _this.hourBlur = _this.hourBlur.bind(_assertThisInitialized(_this));
+    _this.minuteBlur = _this.minuteBlur.bind(_assertThisInitialized(_this));
+    return _this;
+  }
+
+  _createClass(TimeField, [{
+    key: "generateHourSelectValues",
+    value: function generateHourSelectValues() {
+      var hours = (0, _TimeFunctionUtils.generateHours)();
+      var selectValues = [];
+
+      for (var i = 0; i < hours.length; i++) {
+        selectValues.push(_react.default.createElement("option", {
+          key: i,
+          value: i
+        }, i));
+      }
+
+      return selectValues;
+    }
+  }, {
+    key: "generateMinuteSelectValues",
+    value: function generateMinuteSelectValues() {
+      var minutes = (0, _TimeFunctionUtils.generateMinutes)();
+      var selectValues = [];
+
+      for (var i = 0; i < minutes.length; i++) {
+        selectValues.push(_react.default.createElement("option", {
+          key: i,
+          value: i
+        }, minutes[i]));
+      }
+
+      return selectValues;
+    }
+  }, {
+    key: "handleHourChange",
+    value: function handleHourChange(event) {
+      this.props.timeChangeCallback(parseInt(event.target.value), this.props.date.minute(), this.props.mode);
+    }
+  }, {
+    key: "handleMinuteChange",
+    value: function handleMinuteChange(event) {
+      this.props.timeChangeCallback(this.props.date.hour(), parseInt(event.target.value), this.props.mode);
+    }
+  }, {
+    key: "hourFocus",
+    value: function hourFocus() {
+      this.setState({
+        hourFocus: true
+      });
+    }
+  }, {
+    key: "hourBlur",
+    value: function hourBlur() {
+      this.setState({
+        hourFocus: false
+      });
+    }
+  }, {
+    key: "minuteFocus",
+    value: function minuteFocus() {
+      this.setState({
+        minuteFocus: true
+      });
+    }
+  }, {
+    key: "minuteBlur",
+    value: function minuteBlur() {
+      this.setState({
+        minuteFocus: false
+      });
+    }
+  }, {
+    key: "renderSelectField",
+    value: function renderSelectField(valueInput, onChangeInput, optionsInput, id) {
+      var theme = this.props.darkMode ? _StyleUtils.darkTheme : _StyleUtils.lightTheme;
+      return _react.default.createElement("select", {
+        id: id + '_' + this.props.mode,
+        style: theme,
+        value: valueInput,
+        onChange: onChangeInput
+      }, optionsInput);
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var glyphColor = this.props.darkMode ? '#FFFFFF' : '#555';
+      var hours = this.generateHourSelectValues();
+      var minutes = this.generateMinuteSelectValues();
+      var hour = this.props.date.hour();
+      var minute = this.props.date.minute();
+      var hourFocusStyle = {};
+      hourFocusStyle = (0, _StyleUtils.addFocusStyle)(this.state.hourFocus, hourFocusStyle);
+      var minuteFocusStyle = {};
+      minuteFocusStyle = (0, _StyleUtils.addFocusStyle)(this.state.minuteFocus, minuteFocusStyle);
+      return _react.default.createElement("div", {
+        className: "timeContainer"
+      }, _react.default.createElement("div", {
+        className: "timeSelectContainer"
+      }, _react.default.createElement("div", {
+        className: "multipleContentOnLine",
+        onFocus: this.hourFocus,
+        onBlur: this.hourBlur,
+        style: hourFocusStyle
+      }, this.renderSelectField(hour, this.handleHourChange, hours, 'Hour')), _react.default.createElement("div", {
+        className: "multipleContentOnLine"
+      }, ":"), _react.default.createElement("div", {
+        className: "multipleContentOnLine",
+        onFocus: this.minuteFocus,
+        onBlur: this.minuteBlur,
+        style: minuteFocusStyle
+      }, this.renderSelectField(minute, this.handleMinuteChange, minutes, 'Minutes'))), _react.default.createElement(_reactBootstrap.Glyphicon, {
+        style: {
+          color: glyphColor
+        },
+        className: "timeIconStyle",
+        glyph: "time"
+      }));
+    }
+  }]);
+
+  return TimeField;
+}(_react.default.Component);
+
+TimeField.propTypes = {
+  timeChangeCallback: _propTypes.default.func.isRequired,
+  mode: _propTypes.default.string.isRequired,
+  date: _reactMomentProptypes.default.momentObj,
+  darkMode: _propTypes.default.bool
+};
+var _default = TimeField;
+exports.default = _default;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,13 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _DateTimeRangeContainer = _interopRequireDefault(require("./DateTimeRangeContainer"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var _default = _DateTimeRangeContainer.default;
+exports.default = _default;

--- a/dist/ranges/RangeButton.js
+++ b/dist/ranges/RangeButton.js
@@ -1,0 +1,247 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _reactDom = _interopRequireDefault(require("react-dom"));
+
+require("../style/DateTimeRange.css");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _StyleUtils = require("../utils/StyleUtils");
+
+var _TimeFunctionUtils = require("../utils/TimeFunctionUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var RangeButton =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(RangeButton, _React$Component);
+
+  function RangeButton(props) {
+    var _this;
+
+    _classCallCheck(this, RangeButton);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(RangeButton).call(this, props));
+
+    if (props.index === props.selectedRange) {
+      _this.state = {
+        style: (0, _TimeFunctionUtils.rangeButtonSelectedStyle)()
+      };
+    } else {
+      _this.state = {
+        style: (0, _TimeFunctionUtils.rangeButtonStyle)()
+      };
+    }
+
+    _this.mouseEnter = _this.mouseEnter.bind(_assertThisInitialized(_this));
+    _this.mouseLeave = _this.mouseLeave.bind(_assertThisInitialized(_this));
+    _this.onFocus = _this.onFocus.bind(_assertThisInitialized(_this));
+    _this.onBlur = _this.onBlur.bind(_assertThisInitialized(_this));
+    _this.keyDown = _this.keyDown.bind(_assertThisInitialized(_this));
+    return _this;
+  }
+
+  _createClass(RangeButton, [{
+    key: "componentWillReceiveProps",
+    value: function componentWillReceiveProps(nextProps) {
+      var focused = nextProps.focused[nextProps.index]; // If selected index or focused set to selected style
+
+      if (nextProps.index === nextProps.selectedRange || focused) {
+        this.setRangeSelectedStyle();
+      } else {
+        this.setRangeButtonStyle();
+      }
+    }
+  }, {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(prevProps, prevState) {
+      var isComponentViewing = this.props.index === this.props.viewingIndex;
+      var focused = this.props.focused;
+      var focusedOnARange = false;
+
+      for (var i = 0; i < focused.length; i++) {
+        if (focused[i] === true) {
+          focusedOnARange = true;
+          break;
+        }
+      } // If the component we are currently on is the selected viewing component
+      // and we are focused on it according to our focused matrix.
+      // Then add an event listener for this button and set it as focused
+
+
+      if (isComponentViewing && focusedOnARange) {
+        document.addEventListener('keydown', this.keyDown, false);
+        this.button.focus();
+      }
+    }
+  }, {
+    key: "setRangeSelectedStyle",
+    value: function setRangeSelectedStyle() {
+      var style;
+
+      if (this.props.style && this.props.style.customRangeSelected) {
+        style = Object.assign((0, _TimeFunctionUtils.rangeButtonSelectedStyle)(), this.props.style.customRangeSelected);
+      } else {
+        style = (0, _TimeFunctionUtils.rangeButtonSelectedStyle)();
+      }
+
+      this.setState({
+        style: style
+      });
+    }
+  }, {
+    key: "setRangeButtonStyle",
+    value: function setRangeButtonStyle() {
+      var style;
+
+      if (this.props.style && this.props.style.customRangeButtons) {
+        style = Object.assign((0, _TimeFunctionUtils.rangeButtonStyle)(), this.props.style.customRangeButtons);
+      } else {
+        style = (0, _TimeFunctionUtils.rangeButtonStyle)();
+      }
+
+      this.setState({
+        style: style
+      });
+    }
+  }, {
+    key: "mouseEnter",
+    value: function mouseEnter() {
+      // Set hover style
+      this.setRangeSelectedStyle();
+    }
+  }, {
+    key: "mouseLeave",
+    value: function mouseLeave(focused) {
+      var isFocused;
+
+      if (typeof focused === 'boolean') {
+        isFocused = focused;
+      } else {
+        isFocused = this.state.focused;
+      }
+
+      var isSelected = this.props.index === this.props.selectedRange; // If not selected and not focused then on mouse leave set to normal style
+
+      if (!isSelected && !isFocused) {
+        this.setRangeButtonStyle();
+      }
+    }
+  }, {
+    key: "onFocus",
+    value: function onFocus() {
+      this.setState({
+        focused: true
+      });
+      this.props.setFocusedCallback(this.props.index, true);
+      this.mouseEnter(true);
+    }
+  }, {
+    key: "onBlur",
+    value: function onBlur() {
+      this.setState({
+        focused: false
+      });
+      this.props.setFocusedCallback(this.props.index, false);
+      this.mouseLeave(false);
+      document.removeEventListener('keydown', this.keyDown, false);
+    }
+  }, {
+    key: "keyDown",
+    value: function keyDown(e) {
+      var componentFocused = document.activeElement === _reactDom.default.findDOMNode(this.button); // Up Key
+
+
+      if (e.keyCode === 38 && componentFocused) {
+        e.preventDefault();
+        this.props.viewingIndexChangeCallback(this.props.index - 1);
+      } // Down Key
+      else if (e.keyCode === 40 && componentFocused) {
+          e.preventDefault();
+          this.props.viewingIndexChangeCallback(this.props.index + 1);
+        } // Space Bar and Enter
+        else if (e.keyCode === 32 || e.keyCode === 13) {
+            this.props.rangeSelectedCallback(this.props.index, this.props.label);
+          }
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
+
+      var isViewingIndex = this.props.viewingIndex === this.props.index;
+      var tabIndex;
+
+      if (isViewingIndex) {
+        tabIndex = 0;
+      } else {
+        tabIndex = -1;
+      }
+
+      var style = {};
+      style = (0, _StyleUtils.addFocusStyle)(this.state.focused, style);
+      style = Object.assign(style, this.state.style);
+      return _react.default.createElement("div", {
+        ref: function ref(button) {
+          _this2.button = button;
+        },
+        id: "rangeButton" + this.props.index,
+        onMouseEnter: this.mouseEnter,
+        onMouseLeave: this.mouseLeave,
+        onFocus: this.onFocus,
+        onBlur: this.onBlur,
+        tabIndex: tabIndex,
+        style: style,
+        onMouseDown: function onMouseDown() {
+          _this2.props.rangeSelectedCallback(_this2.props.index, _this2.props.label);
+
+          _this2.onFocus();
+        }
+      }, _react.default.createElement("div", {
+        className: "rangebuttontextstyle"
+      }, this.props.label));
+    }
+  }]);
+
+  return RangeButton;
+}(_react.default.Component);
+
+RangeButton.propTypes = {
+  selectedRange: _propTypes.default.number.isRequired,
+  rangeSelectedCallback: _propTypes.default.func.isRequired,
+  viewingIndexChangeCallback: _propTypes.default.func.isRequired,
+  setFocusedCallback: _propTypes.default.func.isRequired,
+  index: _propTypes.default.number.isRequired,
+  viewingIndex: _propTypes.default.number.isRequired,
+  label: _propTypes.default.string.isRequired,
+  focused: _propTypes.default.array.isRequired,
+  style: _propTypes.default.object
+};
+var _default = RangeButton;
+exports.default = _default;

--- a/dist/ranges/Ranges.js
+++ b/dist/ranges/Ranges.js
@@ -1,0 +1,151 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+require("../style/DateTimeRange.css");
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _RangeButton = _interopRequireDefault(require("./RangeButton"));
+
+var _DateTimeRangeContainer = require("../DateTimeRangeContainer");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+var Ranges =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(Ranges, _React$Component);
+
+  function Ranges(props) {
+    var _this;
+
+    _classCallCheck(this, Ranges);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(Ranges).call(this, props));
+    var focused = [];
+    var ranges = Object.keys(_this.props.ranges).map(function (key) {
+      return _this.props.ranges[key];
+    });
+
+    for (var i = 0; i < ranges.length; i++) {
+      focused.push(false);
+    }
+
+    _this.state = {
+      viewingIndex: _this.props.selectedRange,
+      focused: focused
+    };
+    _this.viewingIndexChangeCallback = _this.viewingIndexChangeCallback.bind(_assertThisInitialized(_this));
+    _this.setFocusedCallback = _this.setFocusedCallback.bind(_assertThisInitialized(_this));
+    return _this;
+  }
+
+  _createClass(Ranges, [{
+    key: "componentWillReceiveProps",
+    value: function componentWillReceiveProps(nextProps) {
+      // On Change of Selected Range reset viewing index to be the range index
+      if (this.props.selectedRange !== nextProps.selectedRange) {
+        this.setState({
+          viewingIndex: nextProps.selectedRange
+        });
+      }
+    }
+  }, {
+    key: "viewingIndexChangeCallback",
+    value: function viewingIndexChangeCallback(newIndex) {
+      // Allow a new item selected to be made
+      var length = this.state.focused.length;
+
+      if (newIndex >= 0 && newIndex < length) {
+        this.setState({
+          viewingIndex: newIndex
+        });
+      }
+    }
+  }, {
+    key: "setFocusedCallback",
+    value: function setFocusedCallback(index, focusedInput) {
+      // Set the focus value of indexed item, focusedInput is true or false
+      var focused = this.state.focused;
+      focused[index] = focusedInput;
+      this.setState({
+        focused: focused
+      });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
+
+      var mobileModeActive = !this.props.noMobileMode; // If no mobile mode prop not set then allow mobile mode
+
+      var mobileModeForce = this.props.forceMobileMode; // If force mobile mode prop is set then force mobile mode
+
+      var displayI = '';
+
+      if (this.props.screenWidthToTheRight < _DateTimeRangeContainer.mobileBreakPoint && mobileModeActive || mobileModeForce) {
+        displayI = 'contents';
+      } // Map the range index and object name and value to a range button
+
+
+      return _react.default.createElement("div", {
+        className: "rangecontainer",
+        style: {
+          display: displayI
+        }
+      }, Object.keys(this.props.ranges).map(function (range, i) {
+        return _react.default.createElement(_RangeButton.default, {
+          key: i,
+          index: i,
+          label: range,
+          value: _this2.props.ranges[range],
+          selectedRange: _this2.props.selectedRange,
+          rangeSelectedCallback: _this2.props.rangeSelectedCallback,
+          viewingIndex: _this2.state.viewingIndex,
+          viewingIndexChangeCallback: _this2.viewingIndexChangeCallback,
+          focused: _this2.state.focused,
+          setFocusedCallback: _this2.setFocusedCallback,
+          style: _this2.props.style
+        });
+      }));
+    }
+  }]);
+
+  return Ranges;
+}(_react.default.Component);
+
+Ranges.propTypes = {
+  ranges: _propTypes.default.object.isRequired,
+  screenWidthToTheRight: _propTypes.default.number.isRequired,
+  selectedRange: _propTypes.default.number.isRequired,
+  rangeSelectedCallback: _propTypes.default.func.isRequired,
+  style: _propTypes.default.object,
+  noMobileMode: _propTypes.default.bool,
+  forceMobileMode: _propTypes.default.bool
+};
+var _default = Ranges;
+exports.default = _default;

--- a/dist/style/DateTimeRange.css
+++ b/dist/style/DateTimeRange.css
@@ -1,0 +1,204 @@
+.daterangepickercontainer {
+  position: relative;
+}
+
+.daterangepicker {
+    position: absolute;
+    display: flex;
+    color: inherit;
+    background-color: #fff;
+    border-radius: 4px;
+    padding: 4px;
+    margin-top: 1px;
+    top: 100px;
+    left: 20px;
+    max-width: 680px;
+    z-index: 3001;
+    border: 1px solid rgba(0,0,0,0.15);
+    background-clip: padding-box;
+    box-shadow: 0 6px 12px rgba(0,0,0,.175);
+}
+.daterangepicker:before, .daterangepicker:after {
+  position: absolute;
+  display: inline-block;
+  border-bottom-color: rgba(0, 0, 0, 0.2);
+  content: "";
+}
+.daterangepicker:before {
+  top: -7px;
+  border-right: 7px solid transparent;
+  border-left: 7px solid transparent;
+  border-bottom: 7px solid rgba(0, 0, 0, 0.15);
+}
+.daterangepicker:after {
+  top: -6px;
+  border-right: 6px solid transparent;
+  border-bottom: 6px solid rgba(0, 0, 0, 0.3);
+  border-left: 6px solid transparent;
+}
+
+.daterangepickerleft:before {
+  right: 0px;
+}
+.daterangepickerleft:after {
+  right: 0px;
+}
+
+.rangecontainer {
+    width: 160px;
+}
+
+.rangebuttontextstyle {
+  padding-left: 12px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  padding-right: 12px;
+}
+
+.fromDateTimeContainer {
+  font-size: 13px;
+  width : 270px;
+  margin: 4px;
+}
+
+.fromDateHourContainer {
+  border: 1px solid #f5f5f5;
+  border-radius: 4px;
+}
+
+.dateTimeLabel {
+  text-align: center;
+  font-weight: bold;
+  padding-bottom: 5px;
+}
+
+.inputDate {
+  height: 30px;
+}
+
+.calendarAddon {
+  background-color: inherit;
+}
+
+.timeContainer {
+  text-align: center;
+  position: relative;
+}
+
+.timeSelectContainer {
+  margin : 8px;
+}
+
+.timeIconStyle {
+  position: absolute;
+  top : 3px;
+  left: 14px;
+  font-style: normal;
+}
+
+.multipleContentOnLine {
+  position: relative;
+  display: inline;
+  padding: 1px;
+}
+
+.buttonContainer {
+  position: absolute;
+  display: flex;
+  bottom: 0;
+  right: 0;
+  margin-right: 13px;
+  margin-left: 13px;
+  margin-bottom: 10px;
+  margin-top: 10px;
+}
+
+.buttonSeperator {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+.applyButton {
+  border-color: #4cae4c;
+  color: #fff;
+  font-size: 12px;
+  border-radius: 3px;
+  padding: 5px 10px;
+  cursor: pointer;
+  margin-right: 4px;
+  border: 1px solid #5cb85c;
+}
+
+.cancelButton {
+  background-color: #fff;
+  color: #333;
+  font-size: 12px;
+  border-radius: 3px;
+  padding: 5px 10px;
+  cursor: pointer;
+  border: 1px solid #ccc;
+}
+
+.maxDateLabel {
+  padding: 7px;
+  font-size: 10px;
+}
+
+.monthYearContainer {
+  margin : 5px;
+  margin-top: 15px;
+  display: flex;
+}
+
+.leftChevron {
+  display: grid;
+  width: 25%;
+  padding: 2px;
+  justify-content: left;
+  font-size: 14px;
+}
+
+.rightChevron {
+  display: grid;
+  width: 25%;
+  padding: 2px;
+  justify-content: right;
+  font-size: 14px;
+}
+
+.calendarGrid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+}
+
+.calendarGridFirefoxBelow35 {
+  display: flex;
+  text-align: center;
+}
+
+.calendarGridHeaderFirefoxBelow35 {
+  width: 14%;
+}
+
+.calendarCell {
+  padding: 5px;
+}
+
+.calendarCellFirefoxBelow35 {
+  padding: 5px;
+  width: 14%
+}
+
+.activeNotifier {
+  text-align: center;
+  padding-bottom: 40px;
+}
+
+.dot {
+  height: 10px;
+  width: 10px;
+  background-color: #12bc00;
+  border-radius: 50%;
+  display: inline-block;
+}

--- a/dist/tests/ThirtyDaysTest.test.js
+++ b/dist/tests/ThirtyDaysTest.test.js
@@ -1,0 +1,300 @@
+"use strict";
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _TimeFunctionUtils = require("../utils/TimeFunctionUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_moment.default.locale('en');
+
+describe('DateTimeRangeContainer', function () {
+  it('EN Locale Thirty Days Method Returns Correct June 2018', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(5, 2018);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2018-05-28');
+    var expectedEnd = (0, _moment.default)('2018-07-08');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct July 2018', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(6, 2018);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2018-06-25');
+    var expectedEnd = (0, _moment.default)('2018-08-05');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct October 2018', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(9, 2018);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2018-09-24');
+    var expectedEnd = (0, _moment.default)('2018-11-04');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct September 2018', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(8, 2018);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2018-08-27');
+    var expectedEnd = (0, _moment.default)('2018-10-07');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct May 2018', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(4, 2018);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2018-04-30');
+    var expectedEnd = (0, _moment.default)('2018-06-10');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct Jan 2018', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(0, 2018);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2017-12-25');
+    var expectedEnd = (0, _moment.default)('2018-02-04');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct October 2017', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(9, 2017);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2017-09-25');
+    var expectedEnd = (0, _moment.default)('2017-11-05');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct August 2017', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(7, 2017);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2017-07-31');
+    var expectedEnd = (0, _moment.default)('2017-09-10');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct July 2017', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(6, 2017);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2017-06-26');
+    var expectedEnd = (0, _moment.default)('2017-08-06');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct May 2017', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(4, 2017);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2017-04-24');
+    var expectedEnd = (0, _moment.default)('2017-06-04');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct February 2017', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(1, 2017);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2017-01-30');
+    var expectedEnd = (0, _moment.default)('2017-03-12');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct Leap Year', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(1, 2016);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2016-01-25');
+    var expectedEnd = (0, _moment.default)('2016-03-06');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('EN Locale Thirty Days Method Returns Correct January 2016', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(0, 2016);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2015-12-28');
+    var expectedEnd = (0, _moment.default)('2016-02-07');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct January 2016', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(0, 2016, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2015-12-27');
+    var expectedEnd = (0, _moment.default)('2016-02-06');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct March 2016', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(2, 2016, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2016-02-28');
+    var expectedEnd = (0, _moment.default)('2016-04-09');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct May 2016', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(4, 2016, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2016-04-24');
+    var expectedEnd = (0, _moment.default)('2016-06-04');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct June 2016', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(5, 2016, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2016-05-29');
+    var expectedEnd = (0, _moment.default)('2016-07-09');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct July 2016', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(6, 2016, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2016-06-26');
+    var expectedEnd = (0, _moment.default)('2016-08-06');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct August 2016', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(7, 2016, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2016-07-31');
+    var expectedEnd = (0, _moment.default)('2016-09-10');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct October 2016', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(9, 2016, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2016-09-25');
+    var expectedEnd = (0, _moment.default)('2016-11-05');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct December 2016', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(11, 2016, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2016-11-27');
+    var expectedEnd = (0, _moment.default)('2017-01-07');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct January 2017', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(0, 2017, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2016-12-25');
+    var expectedEnd = (0, _moment.default)('2017-02-04');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct March 2017', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(2, 2017, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2017-02-26');
+    var expectedEnd = (0, _moment.default)('2017-04-08');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+  it('Sunday Start Date Thirty Days Method Returns Correct April 2017', function () {
+    var days = (0, _TimeFunctionUtils.getFourtyTwoDays)(3, 2017, true);
+    var firstDay = days[0];
+    var lastDay = days[41];
+    var expectedStart = (0, _moment.default)('2017-03-26');
+    var expectedEnd = (0, _moment.default)('2017-05-06');
+    var firstDaySame = firstDay.isSame(expectedStart, 'day');
+    var isEndDaySame = lastDay.isSame(expectedEnd, 'day');
+    expect(days.length).toEqual(42);
+    expect(firstDaySame).toEqual(true);
+    expect(isEndDaySame).toEqual(true);
+  });
+});

--- a/dist/tests/apply_buttons_tests/ApplyButton.test.js
+++ b/dist/tests/apply_buttons_tests/ApplyButton.test.js
@@ -1,0 +1,483 @@
+"use strict";
+
+var _react = _interopRequireDefault(require("react"));
+
+var _enzyme = require("enzyme");
+
+var _enzymeAdapterReact = _interopRequireDefault(require("enzyme-adapter-react-15"));
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _reactBootstrap = require("react-bootstrap");
+
+var _DateTimeRangeContainer = _interopRequireDefault(require("../../DateTimeRangeContainer"));
+
+var _ApplyCancelButtons = _interopRequireDefault(require("../../date_picker/ApplyCancelButtons"));
+
+var _RangeButton = _interopRequireDefault(require("../../ranges/RangeButton"));
+
+var _Cell = _interopRequireDefault(require("../../calendar/Cell"));
+
+var _MonthYearSelector = _interopRequireDefault(require("../../calendar/MonthYearSelector"));
+
+var _TimeField = _interopRequireDefault(require("../../date_picker/TimeField"));
+
+var _DateField = _interopRequireDefault(require("../../date_picker/DateField"));
+
+var _DateTimeRangePicker = require("../../DateTimeRangePicker");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _enzyme.configure)({
+  adapter: new _enzymeAdapterReact.default()
+});
+var now = new Date();
+var start = (0, _moment.default)(new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0));
+var end = (0, _moment.default)(start).add(1, 'days').subtract(1, 'seconds');
+var ranges = {
+  'Today Only': [(0, _moment.default)(start), (0, _moment.default)(end)],
+  'Yesterday Only': [(0, _moment.default)(start).subtract(1, 'days'), (0, _moment.default)(end).subtract(1, 'days')],
+  '3 Days': [(0, _moment.default)(start).subtract(3, 'days'), (0, _moment.default)(end)],
+  '5 Days': [(0, _moment.default)(start).subtract(5, 'days'), (0, _moment.default)(end)],
+  '1 Week': [(0, _moment.default)(start).subtract(7, 'days'), (0, _moment.default)(end)],
+  '2 Weeks': [(0, _moment.default)(start).subtract(14, 'days'), (0, _moment.default)(end)],
+  '1 Month': [(0, _moment.default)(start).subtract(1, 'months'), (0, _moment.default)(end)],
+  '90 Days': [(0, _moment.default)(start).subtract(90, 'days'), (0, _moment.default)(end)],
+  '1 Year': [(0, _moment.default)(start).subtract(1, 'years'), (0, _moment.default)(end)]
+};
+var local = {
+  format: 'DD-MM-YYYY HH:mm',
+  sundayFirst: false
+};
+var startDateCallback = '';
+var endDateCallback = '';
+
+var applyCallback = function applyCallback(startDate, endDate) {
+  startDateCallback = startDate;
+  endDateCallback = endDate;
+};
+
+var dateTimeRangeContainer = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+var dateTimeRangeContainerAutoApply = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback,
+  autoApply: true
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+var dateTimeRangeContainerSmartModeAutoApply = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback,
+  autoApply: true,
+  smartMode: true,
+  pastSearchFriendly: true
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+describe('Apply Button Tests Non Auto Apply', function () {
+  beforeEach(function () {
+    startDateCallback = '';
+    endDateCallback = '';
+    start = (0, _moment.default)(new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0));
+    end = (0, _moment.default)(start).add(1, 'days').subtract(1, 'seconds');
+  });
+  it('Render Apply and Cancel Buttons', function () {
+    var applyCancelButtons = dateTimeRangeContainer.find(_ApplyCancelButtons.default);
+    var applyButton = applyCancelButtons.find('.applyButton');
+    expect(applyButton.text()).toEqual('Apply');
+    var cancelButton = applyCancelButtons.find('.cancelButton');
+    expect(cancelButton.text()).toEqual('Cancel');
+  });
+  it('On Click of Apply Button Return Two Dates to Callback', function () {
+    var applyCancelButtons = dateTimeRangeContainer.find(_ApplyCancelButtons.default);
+    var applyButton = applyCancelButtons.find('.applyButton');
+    applyButton.props().onClick();
+    expect(startDateCallback).toEqual(start);
+    expect(endDateCallback).toEqual(end);
+  });
+  it('On Click of Apply Button Close Picker', function () {
+    dateTimeRangeContainer.setState({
+      visible: true
+    });
+    var applyCancelButtons = dateTimeRangeContainer.find(_ApplyCancelButtons.default);
+    var applyButton = applyCancelButtons.find('.applyButton');
+    applyButton.props().onClick();
+    dateTimeRangeContainer.update();
+    var visible = dateTimeRangeContainer.state().visible;
+    expect(visible).toEqual(false);
+    var picker = dateTimeRangeContainer.find('#daterangepicker');
+    expect(picker.props().style.display).toEqual('none');
+  });
+  it('On Click of Cancel Button Close Picker', function () {
+    dateTimeRangeContainer.setState({
+      visible: true
+    });
+    var applyCancelButtons = dateTimeRangeContainer.find(_ApplyCancelButtons.default);
+    var cancelButton = applyCancelButtons.find('.cancelButton');
+    cancelButton.props().onClick();
+    dateTimeRangeContainer.update();
+    var visible = dateTimeRangeContainer.state().visible;
+    expect(visible).toEqual(false);
+    var picker = dateTimeRangeContainer.find('#daterangepicker');
+    expect(picker.props().style.display).toEqual('none');
+  });
+  it('On Click of Range Button Doesnt Call Apply Callback', function () {
+    var rangeButton = dateTimeRangeContainer.find(_RangeButton.default).first().find('div').first();
+    rangeButton.props().onMouseDown();
+    dateTimeRangeContainer.update();
+    expect(startDateCallback).toEqual('');
+    expect(endDateCallback).toEqual('');
+  });
+  it('On Click of Date Doesnt Call Apply Callback', function () {
+    var firstCalenderCell = dateTimeRangeContainer.find(_Cell.default).first().find('div').first();
+    firstCalenderCell.props().onClick();
+    dateTimeRangeContainer.update();
+    expect(startDateCallback).toEqual('');
+    expect(endDateCallback).toEqual('');
+  }); // CANT GET THIS TEST TO WORK DOESNT SEEM TO WORK WITH EVENT LISTENERS
+  // MANUAL TEST REQUIRED
+  // it('On Keyboard Left Press of Date Doesnt Call Apply Callback', () => {
+  //   let firstCalenderCellDiv = dateTimeRangeContainer
+  //     .find(Cell)
+  //     .first()
+  //     .find('div')
+  //     .first();
+  //   firstCalenderCellDiv.props().onClick();
+  //   dateTimeRangeContainer.update();
+  //   let picker = dateTimeRangeContainer.find(DateTimeRangePicker);
+  //   let startDate = picker.state().start;
+  //   let firstCalenderCell = dateTimeRangeContainer
+  //     .find(Cell)
+  //     .first()
+  //     .find('div')
+  //     .first();
+  //
+  //   firstCalenderCell.simulate('focus');
+  //   firstCalenderCell.simulate('keydown', {
+  //     keyCode : 39
+  //   });
+  //   dateTimeRangeContainer.update();
+  //   picker = dateTimeRangeContainer.find(DateTimeRangePicker);
+  //   startDate = picker.state().start;
+  //   expect(startDateCallback).toEqual('');
+  //   expect(endDateCallback).toEqual('');
+  // });
+
+  it('On Change of Hour Doesnt Call Apply Callback', function () {
+    var hourTimeSelector = dateTimeRangeContainer.find(_TimeField.default).first().find('select').first();
+    hourTimeSelector.simulate('change', {
+      target: {
+        value: '10'
+      }
+    });
+    dateTimeRangeContainer.update();
+    hourTimeSelector = dateTimeRangeContainer.find(_TimeField.default).first().find('select').first();
+    expect(hourTimeSelector.props().value).toEqual(10);
+    expect(startDateCallback).toEqual('');
+    expect(endDateCallback).toEqual('');
+  });
+  it('On Change of Minute Doesnt Call Apply Callback', function () {
+    var minuteTimeSelector = dateTimeRangeContainer.find(_TimeField.default).first().find('select').last();
+    minuteTimeSelector.simulate('change', {
+      target: {
+        value: '50'
+      }
+    });
+    dateTimeRangeContainer.update();
+    minuteTimeSelector = dateTimeRangeContainer.find(_TimeField.default).first().find('select').last();
+    expect(minuteTimeSelector.props().value).toEqual(50);
+    expect(startDateCallback).toEqual('');
+    expect(endDateCallback).toEqual('');
+  });
+  it('On Change of From Date Doesnt Call Apply Callback', function () {
+    var minuteTimeSelector = dateTimeRangeContainer.find(_DateField.default).first().find(_reactBootstrap.FormControl).first();
+    minuteTimeSelector.simulate('focus');
+    minuteTimeSelector.simulate('change', {
+      target: {
+        value: '05-07-2016 23:58'
+      }
+    });
+    minuteTimeSelector.simulate('blur');
+    dateTimeRangeContainer.update();
+    minuteTimeSelector = dateTimeRangeContainer.find(_DateField.default).first().find(_reactBootstrap.FormControl).first();
+    expect(minuteTimeSelector.props().value).toEqual('05-07-2016 23:58');
+    var picker = dateTimeRangeContainer.find(_DateTimeRangePicker.DateTimeRangePicker);
+    expect(picker.state().startLabel).toEqual('05-07-2016 23:58');
+    var newDate = (0, _moment.default)('05-07-2016 23:58', _DateTimeRangePicker.momentFormat);
+    expect(picker.state().start).toEqual((0, _moment.default)(newDate));
+    expect(startDateCallback).toEqual('');
+    expect(endDateCallback).toEqual('');
+  });
+});
+describe('Apply Button Tests Auto Apply Parameter', function () {
+  beforeEach(function () {
+    startDateCallback = '';
+    endDateCallback = '';
+    start = (0, _moment.default)(new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0));
+    end = (0, _moment.default)(start).add(1, 'days').subtract(1, 'seconds');
+    dateTimeRangeContainerAutoApply = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+      ranges: ranges,
+      start: start,
+      end: end,
+      local: local,
+      applyCallback: applyCallback,
+      autoApply: true
+    }, _react.default.createElement(_reactBootstrap.FormControl, {
+      id: "formControlsTextB",
+      type: "text",
+      label: "Text",
+      placeholder: "Enter text"
+    })));
+    dateTimeRangeContainerSmartModeAutoApply = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+      ranges: ranges,
+      start: start,
+      end: end,
+      local: local,
+      applyCallback: applyCallback,
+      autoApply: true,
+      smartMode: true
+    }, _react.default.createElement(_reactBootstrap.FormControl, {
+      id: "formControlsTextB",
+      type: "text",
+      label: "Text",
+      placeholder: "Enter text"
+    })));
+  });
+  it('Render Close Button', function () {
+    var applyCancelButtons = dateTimeRangeContainerAutoApply.find(_ApplyCancelButtons.default);
+    var applyButton = applyCancelButtons.find('.applyButton');
+    expect(applyButton.length).toEqual(0);
+    var cancelButton = applyCancelButtons.find('.cancelButton');
+    expect(cancelButton.text()).toEqual('Close');
+  });
+  it('On Click of Close Button Close Picker', function () {
+    dateTimeRangeContainerAutoApply.setState({
+      visible: true
+    });
+    var applyCancelButtons = dateTimeRangeContainerAutoApply.find(_ApplyCancelButtons.default);
+    var cancelButton = applyCancelButtons.find('.cancelButton');
+    cancelButton.props().onClick();
+    dateTimeRangeContainerAutoApply.update();
+    var visible = dateTimeRangeContainerAutoApply.state().visible;
+    expect(visible).toEqual(false);
+    var picker = dateTimeRangeContainerAutoApply.find('#daterangepicker');
+    expect(picker.props().style.display).toEqual('none');
+  });
+  it('On Click of Range Button Does Call Apply Callback', function () {
+    var rangeButton = dateTimeRangeContainerAutoApply.find(_RangeButton.default).first().find('div').first();
+    rangeButton.props().onMouseDown();
+    dateTimeRangeContainerAutoApply.update();
+    expect(startDateCallback).toEqual(start);
+    expect(endDateCallback).toEqual(end);
+  });
+  it('On Click of Range Button Custom Value Doesnt Call Apply Callback', function () {
+    // Done as impossible to set date using custom value it is actually set through
+    // the date picker not through ranges
+    var rangeButton = dateTimeRangeContainerAutoApply.find(_RangeButton.default).last().find('div').first();
+    rangeButton.props().onMouseDown();
+    dateTimeRangeContainerAutoApply.update();
+    expect(startDateCallback).toEqual('');
+    expect(endDateCallback).toEqual('');
+  });
+  it('On Click of Date Does Call Apply Callback', function () {
+    var firstCalenderCell = dateTimeRangeContainerAutoApply.find(_Cell.default).first().find('div').first();
+    firstCalenderCell.props().onClick();
+    var dateFirstCell = dateTimeRangeContainerAutoApply.find(_Cell.default).first().props().cellDay;
+    dateTimeRangeContainerAutoApply.update();
+    var startDateCallbackSame = startDateCallback.isSame(dateFirstCell, 'minute');
+    var endDateCallbackSame = endDateCallback.isSame(end, 'minute');
+    expect(startDateCallbackSame).toEqual(true);
+    expect(endDateCallbackSame).toEqual(true);
+  }); // CANT GET THIS TEST TO WORK DOESNT SEEM TO WORK WITH EVENT LISTENERS
+  // MANUAL TEST REQUIRED
+  // it('On Keyboard Left Press of Date Doesnt Call Apply Callback', () => {
+  //   let firstCalenderCellDiv = dateTimeRangeContainer
+  //     .find(Cell)
+  //     .first()
+  //     .find('div')
+  //     .first();
+  //   firstCalenderCellDiv.props().onClick();
+  //   dateTimeRangeContainer.update();
+  //   let picker = dateTimeRangeContainer.find(DateTimeRangePicker);
+  //   let startDate = picker.state().start;
+  //   let firstCalenderCell = dateTimeRangeContainer
+  //     .find(Cell)
+  //     .first()
+  //     .find('div')
+  //     .first();
+  //
+  //   firstCalenderCell.simulate('focus');
+  //   firstCalenderCell.simulate('keydown', {
+  //     keyCode : 39
+  //   });
+  //   dateTimeRangeContainer.update();
+  //   picker = dateTimeRangeContainer.find(DateTimeRangePicker);
+  //   startDate = picker.state().start;
+  //   expect(startDateCallback).toEqual('');
+  //   expect(endDateCallback).toEqual('');
+  // });
+
+  it('On Change of Hour Does Call Apply Callback', function () {
+    var hourTimeSelector = dateTimeRangeContainerAutoApply.find(_TimeField.default).first().find('select').first();
+    hourTimeSelector.simulate('change', {
+      target: {
+        value: '10'
+      }
+    });
+    dateTimeRangeContainerAutoApply.update(); // Get new selector after update
+
+    hourTimeSelector = dateTimeRangeContainerAutoApply.find(_TimeField.default).first().find('select').first();
+    var startExpected = (0, _moment.default)(start).hour(10);
+    var startDateCallbackSame = startExpected.isSame(startDateCallback, 'minute');
+    var endDateCallbackSame = end.isSame(endDateCallback, 'minute');
+    expect(hourTimeSelector.props().value).toEqual(10);
+    expect(startDateCallbackSame).toEqual(true);
+    expect(endDateCallbackSame).toEqual(true);
+  });
+  it('On Change of Minute Does Call Apply Callback', function () {
+    var minuteTimeSelector = dateTimeRangeContainerAutoApply.find(_TimeField.default).first().find('select').last();
+    minuteTimeSelector.simulate('change', {
+      target: {
+        value: '50'
+      }
+    });
+    dateTimeRangeContainerAutoApply.update();
+    minuteTimeSelector = dateTimeRangeContainerAutoApply.find(_TimeField.default).first().find('select').last();
+    var startExpected = (0, _moment.default)(start).minute(50);
+    var startDateCallbackSame = startExpected.isSame(startDateCallback, 'minute');
+    var endDateCallbackSame = end.isSame(endDateCallback, 'minute');
+    expect(minuteTimeSelector.props().value).toEqual(50);
+    expect(startDateCallbackSame).toEqual(true);
+    expect(endDateCallbackSame).toEqual(true);
+  });
+  it('On Change of From Date Does Call Apply Callback', function () {
+    var dateFieldForm = dateTimeRangeContainerAutoApply.find(_DateField.default).first().find(_reactBootstrap.FormControl).first();
+    dateFieldForm.simulate('focus');
+    dateFieldForm.simulate('change', {
+      target: {
+        value: '05-07-2016 23:58'
+      }
+    });
+    dateFieldForm.simulate('blur');
+    dateTimeRangeContainerAutoApply.update();
+    dateFieldForm = dateTimeRangeContainerAutoApply.find(_DateField.default).first().find(_reactBootstrap.FormControl).first();
+    expect(dateFieldForm.props().value).toEqual('05-07-2016 23:58');
+    var picker = dateTimeRangeContainerAutoApply.find(_DateTimeRangePicker.DateTimeRangePicker);
+    expect(picker.state().startLabel).toEqual('05-07-2016 23:58');
+    var newDate = (0, _moment.default)('05-07-2016 23:58', _DateTimeRangePicker.momentFormat);
+    expect(picker.state().start).toEqual((0, _moment.default)(newDate));
+    expect(startDateCallback).toEqual(newDate);
+    expect(endDateCallback).toEqual(end);
+  });
+  it('On Change of From Date Does Call Apply Callback, When From Date is After Original To Date, Smart Mode', function () {
+    var newStartDate = (0, _moment.default)(end).add(1, 'day');
+    var newStartDateString = newStartDate.format(_DateTimeRangePicker.momentFormat);
+    var dateFieldForm = dateTimeRangeContainerSmartModeAutoApply.find(_DateField.default).first().find(_reactBootstrap.FormControl).first();
+    dateFieldForm.simulate('focus');
+    dateFieldForm.simulate('change', {
+      target: {
+        value: newStartDateString
+      }
+    });
+    dateFieldForm.simulate('blur');
+    dateTimeRangeContainerSmartModeAutoApply.update();
+    dateFieldForm = dateTimeRangeContainerSmartModeAutoApply.find(_DateField.default).first().find(_reactBootstrap.FormControl).first();
+    expect(dateFieldForm.props().value).toEqual(newStartDateString);
+    var picker = dateTimeRangeContainerSmartModeAutoApply.find(_DateTimeRangePicker.DateTimeRangePicker);
+    expect(picker.state().startLabel).toEqual(newStartDateString);
+    var newDate = (0, _moment.default)(newStartDateString, _DateTimeRangePicker.momentFormat);
+    expect(picker.state().start).toEqual((0, _moment.default)(newDate));
+    expect(startDateCallback).toEqual(newDate); // because the From date is now after the original To date a new To date
+    // will have been calculated. This is +1 day after the new start date
+
+    var newEndDate = (0, _moment.default)(newStartDate).add(1, 'day');
+    var endDateCallbackSame = newEndDate.isSame(endDateCallback, 'minute');
+    expect(endDateCallbackSame).toEqual(true);
+  });
+  it('On Change of From Date Doesnt Call Apply Callback, When From Date is After Original To Date,  Non Smart Mode', function () {
+    var newStartDate = (0, _moment.default)(end).add(1, 'day');
+    var newStartDateString = newStartDate.format(_DateTimeRangePicker.momentFormat);
+    var startDateString = (0, _moment.default)(start).format(_DateTimeRangePicker.momentFormat);
+    var dateFieldForm = dateTimeRangeContainerAutoApply.find(_DateField.default).first().find(_reactBootstrap.FormControl).first();
+    dateFieldForm.simulate('focus');
+    dateFieldForm.simulate('change', {
+      target: {
+        value: newStartDateString
+      }
+    });
+    dateFieldForm.simulate('blur');
+    dateTimeRangeContainerAutoApply.update();
+    dateFieldForm = dateTimeRangeContainerAutoApply.find(_DateField.default).first().find(_reactBootstrap.FormControl).first();
+    expect(dateFieldForm.props().value).toEqual(startDateString);
+    var picker = dateTimeRangeContainerAutoApply.find(_DateTimeRangePicker.DateTimeRangePicker);
+    expect(picker.state().startLabel).toEqual(startDateString);
+    expect(picker.state().start).toEqual((0, _moment.default)(start));
+    expect(startDateCallback).toEqual('');
+    expect(endDateCallback).toEqual('');
+  });
+  it('On Change of To Date Does Call Apply Callback. When To Date Change is Before Original From Date, Smart Mode', function () {
+    var dateFieldForm = dateTimeRangeContainerSmartModeAutoApply.find(_DateField.default).last().find(_reactBootstrap.FormControl).first();
+    dateFieldForm.simulate('focus');
+    dateFieldForm.simulate('change', {
+      target: {
+        value: '05-07-2016 23:58'
+      }
+    });
+    dateFieldForm.simulate('blur');
+    dateTimeRangeContainerSmartModeAutoApply.update();
+    dateFieldForm = dateTimeRangeContainerSmartModeAutoApply.find(_DateField.default).last().find(_reactBootstrap.FormControl).first();
+    expect(dateFieldForm.props().value).toEqual('05-07-2016 23:58');
+    var picker = dateTimeRangeContainerSmartModeAutoApply.find(_DateTimeRangePicker.DateTimeRangePicker);
+    expect(picker.state().endLabel).toEqual('05-07-2016 23:58');
+    var newDate = (0, _moment.default)('05-07-2016 23:58', _DateTimeRangePicker.momentFormat);
+    expect(picker.state().end).toEqual((0, _moment.default)(newDate)); // The new End Date is before the original Start date so a new start date will be in the callback
+    // This will be the day before the end date as per the rules
+
+    var expectedNewStartDate = (0, _moment.default)(newDate).subtract(1, 'days');
+    expect(startDateCallback).toEqual(expectedNewStartDate);
+    expect(endDateCallback).toEqual(newDate);
+  });
+  it('On Change of To Date Doesnt Call Apply Callback. When To Date Change is Before Original From Date, Non Smart Mode', function () {
+    var endDateString = (0, _moment.default)(end).format(_DateTimeRangePicker.momentFormat);
+    var dateFieldForm = dateTimeRangeContainerAutoApply.find(_DateField.default).last().find(_reactBootstrap.FormControl).first();
+    dateFieldForm.simulate('focus');
+    dateFieldForm.simulate('change', {
+      target: {
+        value: '05-07-2016 23:58'
+      }
+    });
+    dateFieldForm.simulate('blur');
+    dateTimeRangeContainerAutoApply.update();
+    dateFieldForm = dateTimeRangeContainerAutoApply.find(_DateField.default).last().find(_reactBootstrap.FormControl).first();
+    expect(dateFieldForm.props().value).toEqual(endDateString);
+    var picker = dateTimeRangeContainerAutoApply.find(_DateTimeRangePicker.DateTimeRangePicker);
+    expect(picker.state().endLabel).toEqual(endDateString);
+    var newDate = (0, _moment.default)(endDateString, _DateTimeRangePicker.momentFormat);
+    expect(picker.state().end).toEqual((0, _moment.default)(end));
+    expect(startDateCallback).toEqual('');
+    expect(endDateCallback).toEqual('');
+  });
+});

--- a/dist/tests/calendar/Calendar.test.js
+++ b/dist/tests/calendar/Calendar.test.js
@@ -1,0 +1,416 @@
+"use strict";
+
+var _react = _interopRequireDefault(require("react"));
+
+var _enzyme = require("enzyme");
+
+var _enzymeAdapterReact = _interopRequireDefault(require("enzyme-adapter-react-15"));
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _Calendar = _interopRequireDefault(require("../../calendar/Calendar"));
+
+var _DateTimeRangePicker = require("../../DateTimeRangePicker");
+
+var _CalendarRows = _interopRequireDefault(require("../../calendar/CalendarRows"));
+
+var _Cell = _interopRequireDefault(require("../../calendar/Cell"));
+
+var _CalendarHeader = _interopRequireDefault(require("../../calendar/CalendarHeader"));
+
+var _MonthYearSelector = _interopRequireDefault(require("../../calendar/MonthYearSelector"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _enzyme.configure)({
+  adapter: new _enzymeAdapterReact.default()
+});
+var start = (0, _moment.default)(new Date(2018, 0, 1, 0, 0, 0, 0));
+var end = (0, _moment.default)(start).add(1, 'days');
+var ranges = {
+  'Today Only': [(0, _moment.default)(start), (0, _moment.default)(end)],
+  'Yesterday Only': [(0, _moment.default)(start).subtract(1, 'days'), (0, _moment.default)(end).subtract(1, 'days')],
+  '3 Days': [(0, _moment.default)(start).subtract(3, 'days'), (0, _moment.default)(end)],
+  '5 Days': [(0, _moment.default)(start).subtract(5, 'days'), (0, _moment.default)(end)],
+  '1 Week': [(0, _moment.default)(start).subtract(7, 'days'), (0, _moment.default)(end)],
+  '2 Weeks': [(0, _moment.default)(start).subtract(14, 'days'), (0, _moment.default)(end)],
+  '1 Month': [(0, _moment.default)(start).subtract(1, 'months'), (0, _moment.default)(end)],
+  '90 Days': [(0, _moment.default)(start).subtract(90, 'days'), (0, _moment.default)(end)],
+  '1 Year': [(0, _moment.default)(start).subtract(1, 'years'), (0, _moment.default)(end)]
+};
+var local = {
+  format: 'DD-MM-YYYY HH:mm',
+  sundayFirst: false
+}; // let maxDate = moment(start).add(24, "hour");
+
+var dateSelectedCallback;
+
+var dateSelectedNoTimeCallback = function dateSelectedNoTimeCallback(cellDate) {
+  dateSelectedCallback = cellDate;
+};
+
+var keyboardCellCallback = function keyboardCellCallback(originalDate, newDate) {};
+
+var focusOnCallback = function focusOnCallback(date) {};
+
+var focusDate = false;
+
+var cellFocusedCallback = function cellFocusedCallback(date) {};
+
+var dateTimeRangeCalendarExpectedUseStartMode = (0, _enzyme.mount)(_react.default.createElement(_Calendar.default, {
+  ranges: ranges,
+  date: start,
+  otherDate: end,
+  mode: _DateTimeRangePicker.ModeEnum.start,
+  dateSelectedNoTimeCallback: dateSelectedNoTimeCallback,
+  keyboardCellCallback: keyboardCellCallback,
+  focusOnCallback: focusOnCallback,
+  focusDate: focusDate,
+  cellFocusedCallback: cellFocusedCallback,
+  smartMode: true,
+  local: local
+}));
+var dateTimeRangeCalendarExpectedUseEndMode = (0, _enzyme.mount)(_react.default.createElement(_Calendar.default, {
+  ranges: ranges,
+  date: start,
+  otherDate: end,
+  mode: _DateTimeRangePicker.ModeEnum.end,
+  dateSelectedNoTimeCallback: dateSelectedNoTimeCallback,
+  keyboardCellCallback: keyboardCellCallback,
+  focusOnCallback: focusOnCallback,
+  focusDate: focusDate,
+  cellFocusedCallback: cellFocusedCallback,
+  smartMode: true,
+  local: local
+}));
+var dateTimeRangeCalendarPastFriendlyStartMode = (0, _enzyme.mount)(_react.default.createElement(_Calendar.default, {
+  ranges: ranges,
+  date: start,
+  otherDate: end,
+  mode: _DateTimeRangePicker.ModeEnum.start,
+  dateSelectedNoTimeCallback: dateSelectedNoTimeCallback,
+  keyboardCellCallback: keyboardCellCallback,
+  focusOnCallback: focusOnCallback,
+  focusDate: focusDate,
+  cellFocusedCallback: cellFocusedCallback,
+  local: local,
+  smartMode: true,
+  pastSearchFriendly: true
+}));
+var dateTimeRangeCalendarPastFriendlyEndMode = (0, _enzyme.mount)(_react.default.createElement(_Calendar.default, {
+  ranges: ranges,
+  date: start,
+  otherDate: end,
+  mode: _DateTimeRangePicker.ModeEnum.end,
+  dateSelectedNoTimeCallback: dateSelectedNoTimeCallback,
+  keyboardCellCallback: keyboardCellCallback,
+  focusOnCallback: focusOnCallback,
+  focusDate: focusDate,
+  cellFocusedCallback: cellFocusedCallback,
+  local: local,
+  smartMode: true,
+  pastSearchFriendly: true
+}));
+var dateTimeRangeCalendarSmartModeDisabledStartMode = (0, _enzyme.mount)(_react.default.createElement(_Calendar.default, {
+  ranges: ranges,
+  date: start,
+  otherDate: end,
+  mode: _DateTimeRangePicker.ModeEnum.start,
+  dateSelectedNoTimeCallback: dateSelectedNoTimeCallback,
+  keyboardCellCallback: keyboardCellCallback,
+  focusOnCallback: focusOnCallback,
+  focusDate: focusDate,
+  cellFocusedCallback: cellFocusedCallback,
+  local: local,
+  pastSearchFriendly: true
+}));
+var dateTimeRangeCalendarSmartModeDisabledEndMode = (0, _enzyme.mount)(_react.default.createElement(_Calendar.default, {
+  ranges: ranges,
+  date: start,
+  otherDate: end,
+  mode: _DateTimeRangePicker.ModeEnum.end,
+  dateSelectedNoTimeCallback: dateSelectedNoTimeCallback,
+  keyboardCellCallback: keyboardCellCallback,
+  focusOnCallback: focusOnCallback,
+  focusDate: focusDate,
+  cellFocusedCallback: cellFocusedCallback,
+  local: local,
+  pastSearchFriendly: true
+}));
+var localUSA = {
+  format: 'MM-DD-YYYY HH:mm',
+  sundayFirst: true
+};
+var dateTimeRangeCalendarAmerican = (0, _enzyme.mount)(_react.default.createElement(_Calendar.default, {
+  ranges: ranges,
+  date: start,
+  otherDate: end,
+  mode: _DateTimeRangePicker.ModeEnum.start,
+  dateSelectedNoTimeCallback: dateSelectedNoTimeCallback,
+  keyboardCellCallback: keyboardCellCallback,
+  focusOnCallback: focusOnCallback,
+  focusDate: focusDate,
+  cellFocusedCallback: cellFocusedCallback,
+  smartMode: true,
+  local: localUSA
+}));
+beforeEach(function () {
+  dateSelectedCallback = null;
+});
+describe('DateTimeRangeContainer', function () {
+  it('Render Calendar Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode.first().children().children();
+    expect(wrappingDiv.length).toBe(3);
+  });
+  it('Calendar Rows Renders', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    expect(wrappingDiv.find(_CalendarRows.default).length).toBe(1);
+  });
+  it('Calendar Test Correct Amount of Cells Generated', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    expect(cells.length).toBe(42);
+  });
+  it('Calendar Test January 2018, First Cell set to 27th November, start mode, pastFriendlyMode', function () {
+    var wrappingDiv = dateTimeRangeCalendarPastFriendlyStartMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(0).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2017, 10, 27));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('Calendar Test January 2018, First Cell set to 25th December, end mode, pastFriendlyMode', function () {
+    var wrappingDiv = dateTimeRangeCalendarPastFriendlyEndMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(0).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2017, 11, 25));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('Calendar Test January 2018, First Cell set to 25th December, start mode, smartModeDisabled', function () {
+    var wrappingDiv = dateTimeRangeCalendarSmartModeDisabledStartMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(0).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2017, 11, 25));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('Calendar Test January 2018, First Cell set to 25th December, end mode, smartModeDisabled', function () {
+    var wrappingDiv = dateTimeRangeCalendarSmartModeDisabledEndMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(0).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2017, 11, 25));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('Calendar Test January 2018, First Cell set to 25th December', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(0).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2017, 11, 25));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('Calendar Test January 2018, Last Cell to be Cell set to 4th Feb', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(41).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2018, 1, 4));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('Calendar Test January 2018, 8th Cell is the 1st of Jan', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(7).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2018, 0, 1));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('Calendar Test January 2018, 38th Cell is the 31st of Jan', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(37).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2018, 0, 31));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('Calendar Test January 2018, First Cell Clicked Callback Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var firstCell = cells.at(0);
+    firstCell.simulate('click');
+    var expectedDate = (0, _moment.default)(new Date(2017, 11, 25));
+    expect(dateSelectedCallback.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('Calendar Test January 2018, First Cell Clicked Callback Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var firstCell = cells.at(0);
+    firstCell.simulate('click');
+    var expectedDate = (0, _moment.default)(new Date(2017, 11, 25));
+    expect(dateSelectedCallback.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('Calendar Test January 2018, Last Cell Clicked Callback Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var cells = wrappingDiv.find(_Cell.default);
+    var lastCell = cells.at(41);
+    lastCell.simulate('click');
+    var expectedDate = (0, _moment.default)(new Date(2018, 1, 4));
+    expect(dateSelectedCallback.isSame(expectedDate, 'day')).toBe(true);
+  });
+  it('UK: Expect Headers Mo-Su', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var cells = wrappingDiv.find(_CalendarHeader.default);
+    var headers = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+    var index = 0;
+    var success = true;
+    cells.children().children().forEach(function (node) {
+      if (success) {
+        success = node.contains(_react.default.createElement("div", null, headers[index]));
+        index++;
+      }
+    });
+    expect(success).toBe(true);
+  });
+  it('American: Expect Headers Su-Sat', function () {
+    var wrappingDiv = dateTimeRangeCalendarAmerican;
+    var cells = wrappingDiv.find(_CalendarHeader.default);
+    var headers = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+    var index = 0;
+    var success = true;
+    cells.children().children().forEach(function (node) {
+      if (success) {
+        success = node.contains(_react.default.createElement("div", null, headers[index]));
+        index++;
+      }
+    });
+    expect(success).toBe(true);
+  });
+  it('Calendar Month Set To January Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var monthYearSelector = wrappingDiv.find(_MonthYearSelector.default);
+    var monthSelected = monthYearSelector.children().children().at(1).children().props().value;
+    expect(monthSelected).toBe('January');
+  });
+  it('Calendar Year Set To Be 2018 Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var monthYearSelector = wrappingDiv.find(_MonthYearSelector.default);
+    var yearSelected = monthYearSelector.children().children().at(2).children().props().value;
+    expect(yearSelected).toBe(2018);
+  });
+  it('Calendar Year Change to 2017, Changes Cells Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var monthYearSelector = wrappingDiv.find(_MonthYearSelector.default);
+    monthYearSelector.children().children().at(2).children().simulate('change', {
+      target: {
+        value: 2017
+      }
+    });
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(0).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2016, 11, 26));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true); // Reset To Previous Value
+
+    monthYearSelector.children().children().at(2).children().simulate('change', {
+      target: {
+        value: 2018
+      }
+    });
+  });
+  it('Calendar Left Arrow Press Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var monthYearSelector = wrappingDiv.find(_MonthYearSelector.default);
+    monthYearSelector.children().children().at(0).children().simulate('click');
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(0).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2017, 10, 27));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true); // Reset To Previous Value
+
+    monthYearSelector.children().children().at(3).children().simulate('click');
+  });
+  it('Calendar Right Arrow Press Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var monthYearSelector = wrappingDiv.find(_MonthYearSelector.default);
+    monthYearSelector.children().children().at(3).children().simulate('click');
+    var cells = wrappingDiv.find(_Cell.default);
+    var cellDay = cells.at(0).props().cellDay;
+    var expectedDate = (0, _moment.default)(new Date(2018, 0, 29));
+    expect(cellDay.isSame(expectedDate, 'day')).toBe(true); // Reset To Previous Value
+
+    monthYearSelector.children().children().at(0).children().simulate('click');
+  });
+  it('Calendar Update Month Year after Props Change Test, Different Month Year', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var props = JSON.parse(JSON.stringify(wrappingDiv.props()));
+    props.date = (0, _moment.default)(new Date(2017, 11, 1));
+    props.otherDate = (0, _moment.default)(new Date(2018, 1, 10));
+    wrappingDiv.setProps(props);
+    expect(wrappingDiv.state().year).toBe(2017);
+    expect(wrappingDiv.state().month).toBe(11);
+  });
+  it('Calendar Update Month Year after Props Change Test, Same Month Year Start Mode', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseStartMode;
+    var props = JSON.parse(JSON.stringify(wrappingDiv.props()));
+    props.date = (0, _moment.default)(new Date(2017, 11, 1));
+    props.otherDate = (0, _moment.default)(new Date(2017, 11, 10));
+    wrappingDiv.setProps(props);
+    expect(wrappingDiv.state().year).toBe(2017);
+    expect(wrappingDiv.state().month).toBe(11);
+  });
+  it('Calendar Update Month Year after Props Change Test, Same Month Year Start Mode, Past Friendly Mode', function () {
+    var wrappingDiv = dateTimeRangeCalendarPastFriendlyStartMode;
+    var props = JSON.parse(JSON.stringify(wrappingDiv.props()));
+    props.date = (0, _moment.default)(new Date(2017, 11, 1));
+    props.otherDate = (0, _moment.default)(new Date(2017, 11, 10));
+    wrappingDiv.setProps(props);
+    expect(wrappingDiv.state().year).toBe(2017);
+    expect(wrappingDiv.state().month).toBe(10);
+  });
+  it('Calendar Update Month Year after Props Change Test, Same Month Year End Mode', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUseEndMode;
+    var props = JSON.parse(JSON.stringify(wrappingDiv.props()));
+    props.date = (0, _moment.default)(new Date(2017, 11, 1));
+    props.otherDate = (0, _moment.default)(new Date(2017, 11, 10));
+    wrappingDiv.setProps(props);
+    expect(wrappingDiv.state().year).toBe(2018);
+    expect(wrappingDiv.state().month).toBe(0);
+  });
+  it('Calendar Update Month Year after Props Change Test, Same Month Year End Mode, Past Friendly Mode', function () {
+    var wrappingDiv = dateTimeRangeCalendarPastFriendlyEndMode;
+    var props = JSON.parse(JSON.stringify(wrappingDiv.props()));
+    props.date = (0, _moment.default)(new Date(2017, 11, 1));
+    props.otherDate = (0, _moment.default)(new Date(2017, 11, 10));
+    wrappingDiv.setProps(props);
+    expect(wrappingDiv.state().year).toBe(2017);
+    expect(wrappingDiv.state().month).toBe(11);
+  });
+  it('Calendar Update Month Year after Props Change Test, Same Month Year Start Mode, Smart Mode Disabled', function () {
+    var wrappingDiv = dateTimeRangeCalendarSmartModeDisabledStartMode;
+    var props = JSON.parse(JSON.stringify(wrappingDiv.props()));
+    props.date = (0, _moment.default)(new Date(2017, 11, 1));
+    props.otherDate = (0, _moment.default)(new Date(2017, 11, 10));
+    wrappingDiv.setProps(props);
+    expect(wrappingDiv.state().year).toBe(2017);
+    expect(wrappingDiv.state().month).toBe(11);
+  });
+  it('Calendar Update Month Year after Props Change Test, Same Month Year End Mode, Smart Mode Disabled', function () {
+    var wrappingDiv = dateTimeRangeCalendarSmartModeDisabledEndMode;
+    var props = JSON.parse(JSON.stringify(wrappingDiv.props()));
+    props.date = (0, _moment.default)(new Date(2017, 11, 1));
+    props.otherDate = (0, _moment.default)(new Date(2017, 11, 10));
+    wrappingDiv.setProps(props);
+    expect(wrappingDiv.state().year).toBe(2017);
+    expect(wrappingDiv.state().month).toBe(11);
+  });
+  it('Calendar Update Month Year after Props Change Test, Different Month Year Start Mode, Smart Mode Disabled', function () {
+    var wrappingDiv = dateTimeRangeCalendarSmartModeDisabledStartMode;
+    var props = JSON.parse(JSON.stringify(wrappingDiv.props()));
+    props.date = (0, _moment.default)(new Date(2017, 10, 1));
+    props.otherDate = (0, _moment.default)(new Date(2017, 11, 10));
+    wrappingDiv.setProps(props);
+    expect(wrappingDiv.state().year).toBe(2017);
+    expect(wrappingDiv.state().month).toBe(10);
+  });
+  it('Calendar Update Month Year after Props Change Test, Different Month Year End Mode, Smart Mode Disabled', function () {
+    var wrappingDiv = dateTimeRangeCalendarSmartModeDisabledEndMode;
+    var props = JSON.parse(JSON.stringify(wrappingDiv.props()));
+    props.date = (0, _moment.default)(new Date(2017, 11, 1));
+    props.otherDate = (0, _moment.default)(new Date(2017, 10, 10));
+    wrappingDiv.setProps(props);
+    expect(wrappingDiv.state().year).toBe(2017);
+    expect(wrappingDiv.state().month).toBe(11);
+  });
+});

--- a/dist/tests/calendar/CalendarFocusBlur.test.js
+++ b/dist/tests/calendar/CalendarFocusBlur.test.js
@@ -1,0 +1,97 @@
+"use strict";
+
+var _react = _interopRequireDefault(require("react"));
+
+var _enzyme = require("enzyme");
+
+var _enzymeAdapterReact = _interopRequireDefault(require("enzyme-adapter-react-15"));
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _Calendar = _interopRequireDefault(require("../../calendar/Calendar"));
+
+var _DateTimeRangePicker = require("../../DateTimeRangePicker");
+
+var _CalendarRows = _interopRequireDefault(require("../../calendar/CalendarRows"));
+
+var _Cell = _interopRequireDefault(require("../../calendar/Cell"));
+
+var _CalendarHeader = _interopRequireDefault(require("../../calendar/CalendarHeader"));
+
+var _MonthYearSelector = _interopRequireDefault(require("../../calendar/MonthYearSelector"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _enzyme.configure)({
+  adapter: new _enzymeAdapterReact.default()
+});
+var start = (0, _moment.default)(new Date(2018, 1, 1, 0, 0, 0, 0));
+var end = (0, _moment.default)(start).add(1, 'days');
+var ranges = {
+  'Today Only': [(0, _moment.default)(start), (0, _moment.default)(end)],
+  'Yesterday Only': [(0, _moment.default)(start).subtract(1, 'days'), (0, _moment.default)(end).subtract(1, 'days')],
+  '3 Days': [(0, _moment.default)(start).subtract(3, 'days'), (0, _moment.default)(end)],
+  '5 Days': [(0, _moment.default)(start).subtract(5, 'days'), (0, _moment.default)(end)],
+  '1 Week': [(0, _moment.default)(start).subtract(7, 'days'), (0, _moment.default)(end)],
+  '2 Weeks': [(0, _moment.default)(start).subtract(14, 'days'), (0, _moment.default)(end)],
+  '1 Month': [(0, _moment.default)(start).subtract(1, 'months'), (0, _moment.default)(end)],
+  '90 Days': [(0, _moment.default)(start).subtract(90, 'days'), (0, _moment.default)(end)],
+  '1 Year': [(0, _moment.default)(start).subtract(1, 'years'), (0, _moment.default)(end)]
+};
+var local = {
+  format: 'DD-MM-YYYY HH:mm',
+  sundayFirst: false
+}; // let maxDate = moment(start).add(24, "hour");
+
+var dateSelectedCallback;
+
+var dateSelectedNoTimeCallback = function dateSelectedNoTimeCallback(cellDate) {
+  dateSelectedCallback = cellDate;
+};
+
+var keyboardCellCallback = function keyboardCellCallback(originalDate, newDate) {};
+
+var focusOnCallback = function focusOnCallback(date) {};
+
+var focusDate = false;
+
+var cellFocusedCallback = function cellFocusedCallback(date) {};
+
+var dateTimeRangeCalendarExpectedUse = (0, _enzyme.mount)(_react.default.createElement(_Calendar.default, {
+  ranges: ranges,
+  date: start,
+  otherDate: end,
+  mode: _DateTimeRangePicker.ModeEnum.start,
+  dateSelectedNoTimeCallback: dateSelectedNoTimeCallback,
+  keyboardCellCallback: keyboardCellCallback,
+  focusOnCallback: focusOnCallback,
+  focusDate: focusDate,
+  cellFocusedCallback: cellFocusedCallback,
+  local: local
+}));
+describe('MonthYearSelector Focus Blur Tests', function () {
+  it('Month Focus State Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUse;
+    var monthYearSelector = wrappingDiv.find(_MonthYearSelector.default);
+    monthYearSelector.children().children().at(1).simulate('focus');
+    expect(monthYearSelector.state().monthFocus).toBe(true);
+  });
+  it('Month Blur State Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUse;
+    var monthYearSelector = wrappingDiv.find(_MonthYearSelector.default);
+    monthYearSelector.children().children().at(1).simulate('blur');
+    expect(monthYearSelector.state().monthFocus).toBe(false);
+  });
+  it('Year Focus State Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUse;
+    var monthYearSelector = wrappingDiv.find(_MonthYearSelector.default);
+    monthYearSelector.children().children().at(2).simulate('focus');
+    expect(monthYearSelector.state().yearFocus).toBe(true);
+  });
+  it('Year Blur State Test', function () {
+    var wrappingDiv = dateTimeRangeCalendarExpectedUse;
+    var monthYearSelector = wrappingDiv.find(_MonthYearSelector.default);
+    monthYearSelector.children().children().at(2).simulate('blur');
+    expect(monthYearSelector.state().yearFocus).toBe(false);
+  });
+});

--- a/dist/tests/calendar/CalendarYears.test.js
+++ b/dist/tests/calendar/CalendarYears.test.js
@@ -1,0 +1,246 @@
+"use strict";
+
+var _react = _interopRequireDefault(require("react"));
+
+var _enzyme = require("enzyme");
+
+var _enzymeAdapterReact = _interopRequireDefault(require("enzyme-adapter-react-15"));
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _reactBootstrap = require("react-bootstrap");
+
+var _Calendar = _interopRequireDefault(require("../../calendar/Calendar"));
+
+var _DateTimeRangePicker = require("../../DateTimeRangePicker");
+
+var _YearUtils = require("../../utils/YearUtils");
+
+var _MonthYearSelector = _interopRequireDefault(require("../../calendar/MonthYearSelector"));
+
+var _DateTimeRangeContainer = _interopRequireDefault(require("../../DateTimeRangeContainer"));
+
+var _DatePicker = _interopRequireDefault(require("../../date_picker/DatePicker"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _enzyme.configure)({
+  adapter: new _enzymeAdapterReact.default()
+});
+var start = (0, _moment.default)(new Date(2018, 1, 1, 0, 0, 0, 0));
+var end = (0, _moment.default)(start).add(1, 'days');
+var ranges = {
+  'Today Only': [(0, _moment.default)(start), (0, _moment.default)(end)],
+  'Yesterday Only': [(0, _moment.default)(start).subtract(1, 'days'), (0, _moment.default)(end).subtract(1, 'days')],
+  '3 Days': [(0, _moment.default)(start).subtract(3, 'days'), (0, _moment.default)(end)],
+  '5 Days': [(0, _moment.default)(start).subtract(5, 'days'), (0, _moment.default)(end)],
+  '1 Week': [(0, _moment.default)(start).subtract(7, 'days'), (0, _moment.default)(end)],
+  '2 Weeks': [(0, _moment.default)(start).subtract(14, 'days'), (0, _moment.default)(end)],
+  '1 Month': [(0, _moment.default)(start).subtract(1, 'months'), (0, _moment.default)(end)],
+  '90 Days': [(0, _moment.default)(start).subtract(90, 'days'), (0, _moment.default)(end)],
+  '1 Year': [(0, _moment.default)(start).subtract(1, 'years'), (0, _moment.default)(end)]
+};
+var local = {
+  format: 'DD-MM-YYYY HH:mm',
+  sundayFirst: false
+}; // let maxDate = moment(start).add(24, "hour");
+
+var dateSelectedCallback;
+
+var dateSelectedNoTimeCallback = function dateSelectedNoTimeCallback(cellDate) {
+  dateSelectedCallback = cellDate;
+};
+
+var keyboardCellCallback = function keyboardCellCallback(originalDate, newDate) {};
+
+var focusOnCallback = function focusOnCallback(date) {};
+
+var focusDate = false;
+
+var cellFocusedCallback = function cellFocusedCallback(date) {};
+
+var dateTimeRangeCalendar = (0, _enzyme.mount)(_react.default.createElement(_Calendar.default, {
+  ranges: ranges,
+  date: start,
+  otherDate: end,
+  mode: _DateTimeRangePicker.ModeEnum.start,
+  dateSelectedNoTimeCallback: dateSelectedNoTimeCallback,
+  keyboardCellCallback: keyboardCellCallback,
+  focusOnCallback: focusOnCallback,
+  focusDate: focusDate,
+  cellFocusedCallback: cellFocusedCallback,
+  local: local
+}));
+var dateTimeRangeCalendarDescendingFirst = (0, _enzyme.mount)(_react.default.createElement(_Calendar.default, {
+  ranges: ranges,
+  date: start,
+  otherDate: end,
+  mode: _DateTimeRangePicker.ModeEnum.start,
+  dateSelectedNoTimeCallback: dateSelectedNoTimeCallback,
+  keyboardCellCallback: keyboardCellCallback,
+  focusOnCallback: focusOnCallback,
+  focusDate: focusDate,
+  cellFocusedCallback: cellFocusedCallback,
+  descendingYears: true,
+  local: local
+}));
+var startDateCallback = '';
+var endDateCallback = '';
+
+var applyCallback = function applyCallback(startDate, endDate) {
+  startDateCallback = startDate;
+  endDateCallback = endDate;
+};
+
+var dateTimeRangeContainer = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+var dateTimeRangeContainerDescendingYears = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback,
+  descendingYears: true
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+var customYears = [2016, 2019];
+var dateTimeRangeContainerCustomYears = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback,
+  years: customYears
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+var dateTimeRangeContainerCustomDescendingYears = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback,
+  descendingYears: true,
+  years: customYears
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+beforeEach(function () {
+  dateSelectedCallback = null;
+});
+describe('CalenderYearsTest', function () {
+  it('Render MonthYearSelector', function () {
+    var wrappingDiv = dateTimeRangeCalendar.find(_MonthYearSelector.default).children().children();
+    expect(wrappingDiv.length).toBe(4);
+  });
+  it('Render Years', function () {
+    var wrappingDiv = dateTimeRangeCalendar.find(_MonthYearSelector.default).children().children().at(2);
+    var yearSelect = wrappingDiv.find('select');
+    var years = (0, _YearUtils.createYears)(undefined, false);
+    expect(yearSelect.children().length).toBe(years.length);
+    yearSelect.children().forEach(function (option, i) {
+      expect(option.text()).toEqual(years[i].toString());
+    });
+  });
+
+  var isMonthYearSelectorAscending = function isMonthYearSelectorAscending(MonthYearSelector) {
+    var yearSelector = MonthYearSelector.children().children().at(2);
+    var yearSelect = yearSelector.find('select');
+    var years = (0, _YearUtils.createYears)(undefined, false);
+    expect(yearSelect.children().length).toBe(years.length);
+    yearSelect.children().forEach(function (option, i) {
+      expect(option.text()).toEqual(years[i].toString());
+
+      if (i === 0) {
+        expect(option.text()).toEqual('1900');
+      }
+    });
+  };
+
+  it('Render Years Ascending', function () {
+    var monthYearSelector = dateTimeRangeCalendar.find(_MonthYearSelector.default);
+    return isMonthYearSelectorAscending(monthYearSelector);
+  });
+  it('Render Years Ascending Both Sides', function () {
+    var monthYearSelectors = dateTimeRangeContainer.find(_MonthYearSelector.default);
+    monthYearSelectors.forEach(function (option) {
+      isMonthYearSelectorAscending(option);
+    });
+  });
+
+  var isMonthYearSelectorDescending = function isMonthYearSelectorDescending(MonthYearSelector) {
+    var yearSelector = MonthYearSelector.children().children().at(2);
+    var yearSelect = yearSelector.find('select');
+    var years = (0, _YearUtils.createYears)(undefined, true);
+    expect(yearSelect.children().length).toBe(years.length);
+    yearSelect.children().forEach(function (option, i) {
+      expect(option.text()).toEqual(years[i].toString());
+
+      if (i === 0) {
+        expect(option.text()).toEqual(years[i].toString());
+      }
+    });
+  };
+
+  it('Render Years Descending', function () {
+    var monthYearSelector = dateTimeRangeCalendarDescendingFirst.find(_MonthYearSelector.default);
+    return isMonthYearSelectorDescending(monthYearSelector);
+  });
+  it('Render Years Descending Both Sides', function () {
+    var monthYearSelectors = dateTimeRangeContainerDescendingYears.find(_MonthYearSelector.default);
+    monthYearSelectors.forEach(function (option) {
+      isMonthYearSelectorDescending(option);
+    });
+  });
+  it('Render normal Years, when user years prop not set', function () {
+    var monthYearSelector = dateTimeRangeContainer.find(_MonthYearSelector.default);
+    var yearSelector = monthYearSelector.children().children().at(2);
+    var yearSelect = yearSelector.find('select');
+    var years = (0, _YearUtils.createYears)(undefined, false);
+    expect(yearSelect.children().length).toBe(years.length);
+    yearSelect.children().forEach(function (option, i) {
+      expect(option.text()).toEqual(years[i].toString());
+    });
+  });
+  it('Render user Years, when the user years prop set', function () {
+    var expectedCustomYears = [2016, 2017, 2018, 2019];
+    var monthYearSelector = dateTimeRangeContainerCustomYears.find(_MonthYearSelector.default);
+    var yearSelector = monthYearSelector.children().children().at(2);
+    var yearSelect = yearSelector.find('select');
+    expect(yearSelect.children().length).toBe(expectedCustomYears.length);
+    yearSelect.children().forEach(function (option, i) {
+      expect(option.text()).toEqual(expectedCustomYears[i].toString());
+    });
+  });
+  it('Render user Years and Descend, when user years prop and descend set', function () {
+    var expectedCustomYears = [2016, 2017, 2018, 2019];
+    var monthYearSelector = dateTimeRangeContainerCustomDescendingYears.find(_MonthYearSelector.default);
+    var yearSelector = monthYearSelector.children().children().at(2);
+    var yearSelect = yearSelector.find('select');
+    var customYearsReversed = expectedCustomYears.reverse();
+    expect(yearSelect.children().length).toBe(expectedCustomYears.length);
+    yearSelect.children().forEach(function (option, i) {
+      expect(option.text()).toEqual(customYearsReversed[i].toString());
+    });
+  });
+});

--- a/dist/tests/ranges_test/Ranges.test.js
+++ b/dist/tests/ranges_test/Ranges.test.js
@@ -1,0 +1,273 @@
+"use strict";
+
+var _react = _interopRequireDefault(require("react"));
+
+var _enzyme = require("enzyme");
+
+var _enzymeAdapterReact = _interopRequireDefault(require("enzyme-adapter-react-15"));
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _reactBootstrap = require("react-bootstrap");
+
+var _DateTimeRangeContainer = _interopRequireDefault(require("../../DateTimeRangeContainer"));
+
+var _DateTimeRangePicker = require("../../DateTimeRangePicker");
+
+var _RangeButton = _interopRequireDefault(require("../../ranges/RangeButton"));
+
+var _Ranges = _interopRequireDefault(require("../../ranges/Ranges"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _enzyme.configure)({
+  adapter: new _enzymeAdapterReact.default()
+});
+var now = new Date();
+var start = (0, _moment.default)(new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0));
+var end = (0, _moment.default)(start).add(1, 'days').subtract(1, 'seconds');
+var ranges = {
+  'Today Only': [(0, _moment.default)(start), (0, _moment.default)(end)],
+  'Yesterday Only': [(0, _moment.default)(start).subtract(1, 'days'), (0, _moment.default)(end).subtract(1, 'days')],
+  '3 Days': [(0, _moment.default)(start).subtract(3, 'days'), (0, _moment.default)(end)],
+  '5 Days': [(0, _moment.default)(start).subtract(5, 'days'), (0, _moment.default)(end)],
+  '1 Week': [(0, _moment.default)(start).subtract(7, 'days'), (0, _moment.default)(end)],
+  '2 Weeks': [(0, _moment.default)(start).subtract(14, 'days'), (0, _moment.default)(end)],
+  '1 Month': [(0, _moment.default)(start).subtract(1, 'months'), (0, _moment.default)(end)],
+  '90 Days': [(0, _moment.default)(start).subtract(90, 'days'), (0, _moment.default)(end)],
+  '1 Year': [(0, _moment.default)(start).subtract(1, 'years'), (0, _moment.default)(end)]
+};
+var local = {
+  format: 'DD-MM-YYYY HH:mm',
+  sundayFirst: false
+};
+
+var applyCallback = function applyCallback(startDate, endDate) {
+  console.log(startDate);
+  console.log(endDate);
+};
+
+var indexCallbackRecieved = '';
+var valueCallbackRecieved = '';
+
+var rangeCallback = function rangeCallback(index, value) {
+  indexCallbackRecieved = index;
+  valueCallbackRecieved = value;
+};
+
+var dateTimeRangeContainerRangeCallback = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback,
+  rangeCallback: rangeCallback
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+var dateTimeRangeContainerNoRangeCallback = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+describe('Ranges Callback Tests', function () {
+  beforeEach(function () {
+    indexCallbackRecieved = '';
+    valueCallbackRecieved = '';
+    rangesMounted = (0, _enzyme.mount)(_react.default.createElement(_Ranges.default, {
+      ranges: ranges,
+      screenWidthToTheRight: 250,
+      selectedRange: 0,
+      rangeSelectedCallback: rangeSelectedCallback
+    }));
+  });
+  it('On Click, First Range, Callback occurs, Callback prop set', function () {
+    var rangeButtons = dateTimeRangeContainerRangeCallback.find(_RangeButton.default);
+    var firstButton = rangeButtons.first();
+    firstButton.children().props().onMouseDown();
+    expect(indexCallbackRecieved).toEqual(0);
+    expect(ranges[valueCallbackRecieved]).toEqual(ranges['Today Only']);
+  });
+  it('On Click, Last Range, Callback occurs, Callback prop set', function () {
+    var rangeButtons = dateTimeRangeContainerRangeCallback.find(_RangeButton.default);
+    var lastButton = rangeButtons.last();
+    lastButton.children().props().onMouseDown();
+    expect(indexCallbackRecieved).toEqual(Object.keys(ranges).length);
+    expect(valueCallbackRecieved).toEqual('Custom Range');
+  });
+  it('"On Click Callback doesnt occur, Callback prop not set', function () {
+    var rangeButtons = dateTimeRangeContainerNoRangeCallback.find(_RangeButton.default);
+    var firstButton = rangeButtons.first();
+    firstButton.children().props().onMouseDown();
+    expect(indexCallbackRecieved).toEqual('');
+    expect(valueCallbackRecieved).toEqual('');
+  });
+});
+
+var rangeSelectedCallback = function rangeSelectedCallback(index, label) {
+  console.log(index, label);
+};
+
+var rangesMounted = (0, _enzyme.mount)(_react.default.createElement(_Ranges.default, {
+  ranges: ranges,
+  screenWidthToTheRight: 250,
+  selectedRange: 0,
+  rangeSelectedCallback: rangeSelectedCallback
+}));
+describe('Ranges Clicked', function () {
+  it('Does date range picker add custom date', function () {
+    var picker = dateTimeRangeContainerNoRangeCallback.find(_DateTimeRangePicker.DateTimeRangePicker);
+    expect(picker.state().ranges['Custom Range']).toEqual('Custom Range');
+  });
+  it('When initially selected 0 range set to focus if selectedRange is 0', function () {
+    expect(rangesMounted.state().viewingIndex).toEqual(0);
+    expect(rangesMounted.find(_RangeButton.default).at(0).state()).toEqual({
+      style: {
+        backgroundColor: '#08c',
+        border: '1px solid #f5f5f5',
+        borderRadius: '4px',
+        color: '#f5f5f5',
+        cursor: 'pointer',
+        fontSize: '13px',
+        marginBottom: '8px',
+        marginLeft: '4px',
+        marginRight: '4px',
+        marginTop: '4px'
+      }
+    });
+  });
+  it('When initially selected 2 range set to focus if selectedRange is 2', function () {
+    var rangesMounted = (0, _enzyme.mount)(_react.default.createElement(_Ranges.default, {
+      ranges: ranges,
+      screenWidthToTheRight: 250,
+      selectedRange: 2,
+      rangeSelectedCallback: rangeSelectedCallback
+    }));
+    expect(rangesMounted.state().viewingIndex).toEqual(2);
+    expect(rangesMounted.find(_RangeButton.default).at(2).state()).toEqual({
+      style: {
+        backgroundColor: '#08c',
+        border: '1px solid #f5f5f5',
+        borderRadius: '4px',
+        color: '#f5f5f5',
+        cursor: 'pointer',
+        fontSize: '13px',
+        marginBottom: '8px',
+        marginLeft: '4px',
+        marginRight: '4px',
+        marginTop: '4px'
+      }
+    });
+  });
+  it('On Click Yesterday (1) Ranges focused state (1) set to true, false everything else', function () {
+    var rangesMounted = (0, _enzyme.mount)(_react.default.createElement(_Ranges.default, {
+      ranges: ranges,
+      screenWidthToTheRight: 250,
+      selectedRange: 2,
+      rangeSelectedCallback: rangeSelectedCallback
+    }));
+    var yesterdayButton = rangesMounted.find(_RangeButton.default).at(1);
+    yesterdayButton.find('div').first().props().onMouseDown();
+    rangesMounted.update();
+    var focused = rangesMounted.state().focused;
+    var error = false;
+
+    for (var i = 0; i < ranges.length; i++) {
+      if (i === 1 && focused[i] === false) {
+        error = true;
+      } else if (focused[i] === true) {
+        error = true;
+      }
+    }
+
+    expect(error).toEqual(false);
+    console.log(rangesMounted.state());
+  });
+  it('On Click Yesterday (1) Style, tabIndex and viewingIndex on button updates to focused', function () {
+    var selectedRange = 1;
+
+    var rangeSelectedCallback = function rangeSelectedCallback(index, value) {
+      selectedRange = index;
+    };
+
+    var rangesMounted = (0, _enzyme.mount)(_react.default.createElement(_Ranges.default, {
+      ranges: ranges,
+      screenWidthToTheRight: 250,
+      selectedRange: selectedRange,
+      rangeSelectedCallback: rangeSelectedCallback
+    }));
+    var yesterdayButton = rangesMounted.find(_RangeButton.default).at(1);
+    yesterdayButton.find('div').first().props().onMouseDown();
+    rangesMounted.update();
+    yesterdayButton = rangesMounted.find(_RangeButton.default).at(1); // Ensure the button at index 1 (Yesterday) is set to focused and correct tabIndex
+
+    var style = yesterdayButton.find('div').first().props().style;
+    expect(style).toEqual({
+      backgroundColor: '#08c',
+      border: '1px solid #f5f5f5',
+      borderRadius: '4px',
+      color: '#f5f5f5',
+      cursor: 'pointer',
+      fontSize: '13px',
+      marginBottom: '8px',
+      marginLeft: '4px',
+      marginRight: '4px',
+      marginTop: '4px',
+      outline: 'cornflowerblue',
+      outlineStyle: 'auto'
+    });
+    expect(rangesMounted.state().viewingIndex).toEqual(1);
+    expect(yesterdayButton.find('div').first().props().tabIndex).toEqual(0); // Ensure all other buttons are not styled as focused or tab indexed in
+
+    rangesMounted.find(_RangeButton.default).forEach(function (button, index) {
+      if (index !== 1) {
+        var _style = button.find('div').first().props().style;
+        expect(_style).toEqual({
+          backgroundColor: '#f5f5f5',
+          border: '1px solid #f5f5f5',
+          borderRadius: '4px',
+          color: '#08c',
+          cursor: 'pointer',
+          fontSize: '13px',
+          marginBottom: '8px',
+          marginLeft: '4px',
+          marginRight: '4px',
+          marginTop: '4px',
+          outlineStyle: ''
+        });
+        expect(button.find('div').first().props().tabIndex).toEqual(-1);
+      }
+    });
+  });
+  it('On Click Yesterday (1) Range Selected Callback returns correct values', function () {
+    var selectedRange = 0;
+    var valueCallback, indexCallback;
+
+    var rangeSelectedCallback = function rangeSelectedCallback(index, value) {
+      valueCallback = value;
+      indexCallback = index;
+    };
+
+    var rangesMounted = (0, _enzyme.mount)(_react.default.createElement(_Ranges.default, {
+      ranges: ranges,
+      screenWidthToTheRight: 250,
+      selectedRange: selectedRange,
+      rangeSelectedCallback: rangeSelectedCallback
+    }));
+    var yesterdayButton = rangesMounted.find(_RangeButton.default).at(1);
+    yesterdayButton.find('div').first().props().onMouseDown();
+    rangesMounted.update();
+    expect(valueCallback).toEqual('Yesterday Only');
+    expect(indexCallback).toEqual(1);
+  });
+});

--- a/dist/tests/render_tests/DoesRender.test.js
+++ b/dist/tests/render_tests/DoesRender.test.js
@@ -1,0 +1,76 @@
+"use strict";
+
+var _react = _interopRequireDefault(require("react"));
+
+var _enzyme = require("enzyme");
+
+var _enzymeAdapterReact = _interopRequireDefault(require("enzyme-adapter-react-15"));
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _reactBootstrap = require("react-bootstrap");
+
+var _DateTimeRangeContainer = _interopRequireDefault(require("../../DateTimeRangeContainer"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _enzyme.configure)({
+  adapter: new _enzymeAdapterReact.default()
+});
+var now = new Date();
+var start = (0, _moment.default)(new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0));
+var end = (0, _moment.default)(start).add(1, 'days').subtract(1, 'seconds');
+var ranges = {
+  'Today Only': [(0, _moment.default)(start), (0, _moment.default)(end)],
+  'Yesterday Only': [(0, _moment.default)(start).subtract(1, 'days'), (0, _moment.default)(end).subtract(1, 'days')],
+  '3 Days': [(0, _moment.default)(start).subtract(3, 'days'), (0, _moment.default)(end)],
+  '5 Days': [(0, _moment.default)(start).subtract(5, 'days'), (0, _moment.default)(end)],
+  '1 Week': [(0, _moment.default)(start).subtract(7, 'days'), (0, _moment.default)(end)],
+  '2 Weeks': [(0, _moment.default)(start).subtract(14, 'days'), (0, _moment.default)(end)],
+  '1 Month': [(0, _moment.default)(start).subtract(1, 'months'), (0, _moment.default)(end)],
+  '90 Days': [(0, _moment.default)(start).subtract(90, 'days'), (0, _moment.default)(end)],
+  '1 Year': [(0, _moment.default)(start).subtract(1, 'years'), (0, _moment.default)(end)]
+};
+var local = {
+  format: 'DD-MM-YYYY HH:mm',
+  sundayFirst: false
+}; // let maxDate = moment(start).add(24, "hour");
+
+var applyCallback = function applyCallback(startDate, endDate) {
+  console.log(startDate);
+  console.log(endDate);
+};
+
+var dateTimeRangeContainerExpectedUse = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+var dateTimeRangeContainerNoChildren = (0, _enzyme.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback
+}));
+describe('DateTimeRangeContainer', function () {
+  it("Always Renders Div's", function () {
+    expect(dateTimeRangeContainerExpectedUse.length).toBeGreaterThan(0);
+  });
+  it('Always render children Div and Daterange div', function () {
+    var wrappingDiv = dateTimeRangeContainerExpectedUse.first().children().children(); // console.log(wrappingDiv.debug());
+
+    expect(wrappingDiv.length).toBeGreaterThan(1);
+  });
+  it('No Child Present, Children Div Not rendered', function () {
+    var wrappingDiv = dateTimeRangeContainerNoChildren.first().children().children();
+    expect(wrappingDiv.length).toBe(1);
+  });
+});

--- a/dist/tests/selecting_mode_tests/SelectingMode.test.js
+++ b/dist/tests/selecting_mode_tests/SelectingMode.test.js
@@ -1,0 +1,112 @@
+"use strict";
+
+var _build = require("enzyme/build");
+
+var _reactBootstrap = require("react-bootstrap");
+
+var _react = _interopRequireDefault(require("react"));
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _enzymeAdapterReact = _interopRequireDefault(require("enzyme-adapter-react-15"));
+
+var _DateTimeRangeContainer = _interopRequireDefault(require("../../DateTimeRangeContainer"));
+
+var _ActiveNotifier = _interopRequireDefault(require("../../date_picker/ActiveNotifier"));
+
+var _Cell = _interopRequireDefault(require("../../calendar/Cell"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _build.configure)({
+  adapter: new _enzymeAdapterReact.default()
+});
+var now = new Date();
+var start = (0, _moment.default)(new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0));
+var end = (0, _moment.default)(start).add(1, 'days').subtract(1, 'seconds');
+var ranges = {
+  'Today Only': [(0, _moment.default)(start), (0, _moment.default)(end)],
+  'Yesterday Only': [(0, _moment.default)(start).subtract(1, 'days'), (0, _moment.default)(end).subtract(1, 'days')],
+  '3 Days': [(0, _moment.default)(start).subtract(3, 'days'), (0, _moment.default)(end)],
+  '5 Days': [(0, _moment.default)(start).subtract(5, 'days'), (0, _moment.default)(end)],
+  '1 Week': [(0, _moment.default)(start).subtract(7, 'days'), (0, _moment.default)(end)],
+  '2 Weeks': [(0, _moment.default)(start).subtract(14, 'days'), (0, _moment.default)(end)],
+  '1 Month': [(0, _moment.default)(start).subtract(1, 'months'), (0, _moment.default)(end)],
+  '90 Days': [(0, _moment.default)(start).subtract(90, 'days'), (0, _moment.default)(end)],
+  '1 Year': [(0, _moment.default)(start).subtract(1, 'years'), (0, _moment.default)(end)]
+};
+var local = {
+  format: 'DD-MM-YYYY HH:mm',
+  sundayFirst: false
+}; // let maxDate = moment(start).add(24, "hour");
+
+var applyCallback = function applyCallback(startDate, endDate) {};
+
+var dateTimeRangeContainerSmartMode = (0, _build.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback,
+  smartMode: true
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+var dateTimeRangeContainer = (0, _build.mount)(_react.default.createElement(_DateTimeRangeContainer.default, {
+  ranges: ranges,
+  start: start,
+  end: end,
+  local: local,
+  applyCallback: applyCallback
+}, _react.default.createElement(_reactBootstrap.FormControl, {
+  id: "formControlsTextB",
+  type: "text",
+  label: "Text",
+  placeholder: "Enter text"
+})));
+describe('Selecting Mode Changes Tests', function () {
+  it('Smart mode starts with Selecting From Only', function () {
+    var notifier = dateTimeRangeContainerSmartMode.find(_ActiveNotifier.default);
+    expect(notifier.at(0).children().text()).toEqual('Selecting From  ');
+    expect(notifier.at(1).children().text()).toEqual('');
+  });
+  it('Smart mode on select changed to only Selecting To', function () {
+    dateTimeRangeContainerSmartMode.find(_Cell.default).at(0).children().props().onClick();
+    dateTimeRangeContainerSmartMode.update();
+    var notifier = dateTimeRangeContainerSmartMode.find(_ActiveNotifier.default);
+    expect(notifier.at(0).children().text()).toEqual('');
+    expect(notifier.at(1).children().text()).toEqual('Selecting To  ');
+  });
+  it('Smart mode on select changed to Selecting From, previously Selecting To ', function () {
+    var cellLength = dateTimeRangeContainerSmartMode.find(_Cell.default).length;
+    dateTimeRangeContainerSmartMode.find(_Cell.default).at(cellLength - 1).children().props().onClick();
+    dateTimeRangeContainerSmartMode.update();
+    var notifier = dateTimeRangeContainerSmartMode.find(_ActiveNotifier.default);
+    expect(notifier.at(0).children().text()).toEqual('Selecting From  ');
+    expect(notifier.at(1).children().text()).toEqual('');
+  });
+  it('No Smart Mode, both From and To Show', function () {// dateTimeRangeContainer
+    //   .find(Cell)
+    //   .at(0)
+    //   .children()
+    //   .props()
+    //   .onClick();
+    // dateTimeRangeContainerSmartMode.update();
+    // let notifier = dateTimeRangeContainerSmartMode.find(ActiveNotifier);
+    // expect(
+    //   notifier
+    //     .at(0)
+    //     .children()
+    //     .text(),
+    // ).toEqual('');
+    // expect(
+    //   notifier
+    //     .at(1)
+    //     .children()
+    //     .text(),
+    // ).toEqual('Selecting To  ');
+  });
+});

--- a/dist/tests/utils_tests/DateSelectedUtils.test.js
+++ b/dist/tests/utils_tests/DateSelectedUtils.test.js
@@ -1,0 +1,158 @@
+"use strict";
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _DateSelectedUtils = require("../../utils/DateSelectedUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_moment.default.locale('en');
+
+describe('Time Function Utils Tests', function () {
+  it('Date Picked, Start Mode, Start Before End Check', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0));
+    var newDate = (0, _moment.default)(new Date(2018, 0, 10));
+    var end = (0, _moment.default)(new Date(2018, 1, 1));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, true);
+    var expectedStartDate = (0, _moment.default)(new Date(2018, 0, 10));
+    var expectedEndDate = (0, _moment.default)(new Date(2018, 1, 1));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Date Picked, Start Mode, Start Same As End Check', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0));
+    var newDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var end = (0, _moment.default)(new Date(2018, 0, 0));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, true);
+    var expectedStartDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var expectedEndDate = (0, _moment.default)(new Date(2018, 0, 0));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Date Picked, Start Mode, Start After End Check, Smart Mode Enabled', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0));
+    var newDate = (0, _moment.default)(new Date(2018, 0, 10));
+    var end = (0, _moment.default)(new Date(2018, 0, 0));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, true, true);
+    var expectedStartDate = (0, _moment.default)(new Date(2018, 0, 10));
+    var expectedEndDate = (0, _moment.default)(new Date(2018, 0, 11));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Date Picked, Start Mode, Start After End Check, Smart Mode Disabled', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0, 0, 0));
+    var newDate = (0, _moment.default)(new Date(2018, 0, 10, 0, 0));
+    var end = (0, _moment.default)(new Date(2018, 0, 1, 0, 0));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, true, false);
+    var expectedStartDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var expectedEndDate = (0, _moment.default)(new Date(2018, 0, 1));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Date Picked, Start Mode, Start After End Check (By 1 Minute), Smart Mode Disabled', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0, 1, 0));
+    var newDate = (0, _moment.default)(new Date(2018, 0, 1, 1, 0));
+    var end = (0, _moment.default)(new Date(2018, 0, 1, 0, 0));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, true, false);
+    var expectedStartDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var expectedEndDate = (0, _moment.default)(new Date(2018, 0, 1));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Date Picked, Start Mode, Start Exactly End Check, Smart Mode Disabled', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0, 1, 0));
+    var newDate = (0, _moment.default)(new Date(2018, 0, 1, 1, 0));
+    var end = (0, _moment.default)(new Date(2018, 0, 1, 1, 0));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, true, false);
+    var expectedStartDate = (0, _moment.default)(new Date(2018, 0, 1));
+    var expectedEndDate = (0, _moment.default)(new Date(2018, 0, 1));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Date Picked, Start Mode, Start Before End Check, Smart Mode Disabled', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0, 0, 0));
+    var newDate = (0, _moment.default)(new Date(2018, 0, 0, 0, 0));
+    var end = (0, _moment.default)(new Date(2018, 0, 1, 1, 0));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, true, false);
+    var expectedStartDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var expectedEndDate = (0, _moment.default)(new Date(2018, 0, 1));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Date Picked, End Mode, End After Start Check', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0));
+    var newDate = (0, _moment.default)(new Date(2018, 0, 10));
+    var end = (0, _moment.default)(new Date(2018, 1, 1));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, false);
+    var expectedStartDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var expectedEndDate = (0, _moment.default)(new Date(2018, 0, 10));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Date Picked, End Mode, End After Start Check, Smart Mode Disabled', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0));
+    var newDate = (0, _moment.default)(new Date(2018, 0, 10));
+    var end = (0, _moment.default)(new Date(2018, 1, 1));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, false);
+    var expectedStartDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var expectedEndDate = (0, _moment.default)(new Date(2018, 0, 10));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Date Picked, End Mode, End Same As Start Check', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0));
+    var newDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var end = (0, _moment.default)(new Date(2018, 0, 0));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, false);
+    var expectedStartDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var expectedEndDate = (0, _moment.default)(new Date(2018, 0, 0));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Date Picked, End Mode, End Before Start Check', function () {
+    var start = (0, _moment.default)(new Date(2018, 0, 0));
+    var newDate = (0, _moment.default)(new Date(2017, 11, 30));
+    var end = (0, _moment.default)(new Date(2018, 0, 0));
+    var dates = (0, _DateSelectedUtils.datePicked)(start, end, newDate, false, true);
+    var expectedStartDate = (0, _moment.default)(new Date(2017, 11, 29));
+    var expectedEndDate = (0, _moment.default)(new Date(2017, 11, 30));
+    expect(expectedStartDate.isSame(dates.startDate, 'day')).toEqual(true);
+    expect(expectedEndDate.isSame(dates.endDate, 'day')).toEqual(true);
+  });
+  it('Past Max Date Test, No Max Date', function () {
+    var currentDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var maxDate = (0, _moment.default)(new Date(2018, 0, 10));
+    var outcome = (0, _DateSelectedUtils.pastMaxDate)(currentDate);
+    expect(outcome).toEqual(false);
+  });
+  it('Past Max Date Test, Minute Mode, Date Past Max', function () {
+    var currentDate = (0, _moment.default)(new Date(2018, 0, 0, 10));
+    var maxDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var outcome = (0, _DateSelectedUtils.pastMaxDate)(currentDate, maxDate, true);
+    expect(outcome).toEqual(true);
+  });
+  it('Past Max Date Test, Minute Mode, Date Not Past Max', function () {
+    var currentDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var maxDate = (0, _moment.default)(new Date(2018, 0, 10));
+    var outcome = (0, _DateSelectedUtils.pastMaxDate)(currentDate, maxDate, true);
+    expect(outcome).toEqual(false);
+  });
+  it('Past Max Date Test, Not Minute Mode, Date Not Past Max', function () {
+    var currentDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var maxDate = (0, _moment.default)(new Date(2018, 0, 25));
+    var outcome = (0, _DateSelectedUtils.pastMaxDate)(currentDate, maxDate, false);
+    expect(outcome).toEqual(false);
+  });
+  it('Past Max Date Test, Not Minute Mode, Date Past Max', function () {
+    var currentDate = (0, _moment.default)(new Date(2018, 0, 10));
+    var maxDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var outcome = (0, _DateSelectedUtils.pastMaxDate)(currentDate, maxDate, false);
+    expect(outcome).toEqual(true);
+  });
+  it('Past Max Date Test, Not Minute Mode, Date Not Past Max, Hour Is Though', function () {
+    var currentDate = (0, _moment.default)(new Date(2018, 0, 0, 1));
+    var maxDate = (0, _moment.default)(new Date(2018, 0, 0));
+    var outcome = (0, _DateSelectedUtils.pastMaxDate)(currentDate, maxDate, false);
+    expect(outcome).toEqual(false);
+  });
+});

--- a/dist/tests/utils_tests/PropValidation.test.js
+++ b/dist/tests/utils_tests/PropValidation.test.js
@@ -1,0 +1,105 @@
+"use strict";
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _PropValidation = require("../../utils/PropValidation");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+describe('Prop Validation Tests', function () {
+  it('Prop years error when not an array', function () {
+    var props = {
+      years: 2012
+    };
+    var validation = (0, _PropValidation.propValidation)(props);
+    expect(validation).toEqual('Year props should be an array e.g. [2019, 2020]');
+  });
+  it('Prop error when years not array of 2', function () {
+    var start = (0, _moment.default)(new Date(2018, 1, 1, 0, 0, 0, 0));
+    var end = (0, _moment.default)(new Date(2012, 1, 1, 0, 0, 0, 0));
+    var props = {
+      years: [2012],
+      start: start,
+      end: end
+    };
+    var validation = (0, _PropValidation.propValidation)(props);
+    expect(validation).toEqual('Year props should be an array of 2, with the first number being the start date and the second being the end');
+  });
+  it('Prop error when start date not in years defined', function () {
+    var start = (0, _moment.default)(new Date(2018, 1, 1, 0, 0, 0, 0));
+    var end = (0, _moment.default)(new Date(2012, 1, 1, 0, 0, 0, 0));
+    var props = {
+      years: [2012, 2013],
+      start: start,
+      end: end
+    };
+    var validation = (0, _PropValidation.propValidation)(props);
+    expect(validation).toEqual('Start year should be in the custom years defined');
+  });
+  it('Prop error when end date not in years defined', function () {
+    var start = (0, _moment.default)(new Date(2012, 1, 1, 0, 0, 0, 0));
+    var end = (0, _moment.default)(new Date(2018, 1, 1, 0, 0, 0, 0));
+    var props = {
+      years: [2012, 2013],
+      start: start,
+      end: end
+    };
+    var validation = (0, _PropValidation.propValidation)(props);
+    expect(validation).toEqual('End year should be in the custom years defined');
+  });
+  it('No prop error when end date in years defined', function () {
+    var start = (0, _moment.default)(new Date(2012, 1, 1, 0, 0, 0, 0));
+    var end = (0, _moment.default)(new Date(2012, 1, 1, 0, 0, 0, 0));
+    var props = {
+      years: [2012, 2013],
+      start: start,
+      end: end
+    };
+    var validation = (0, _PropValidation.propValidation)(props);
+    expect(validation).toEqual(true);
+  });
+  it('No prop error when start date in years defined', function () {
+    var start = (0, _moment.default)(new Date(2012, 1, 1, 0, 0, 0, 0));
+    var end = (0, _moment.default)(new Date(2012, 1, 1, 0, 0, 0, 0));
+    var props = {
+      years: [2012, 2013],
+      start: start,
+      end: end
+    };
+    var validation = (0, _PropValidation.propValidation)(props);
+    expect(validation).toEqual(true);
+  });
+  it('Prop error when years start date after end', function () {
+    var start = (0, _moment.default)(new Date(2014, 1, 1, 0, 0, 0, 0));
+    var end = (0, _moment.default)(new Date(2014, 1, 1, 0, 0, 0, 0));
+    var props = {
+      years: [2014, 2013],
+      start: start,
+      end: end
+    };
+    var validation = (0, _PropValidation.propValidation)(props);
+    expect(validation).toEqual('Start year must be before the end');
+  });
+  it('No prop error when years start date equals end', function () {
+    var start = (0, _moment.default)(new Date(2013, 1, 1, 0, 0, 0, 0));
+    var end = (0, _moment.default)(new Date(2013, 1, 1, 0, 0, 0, 0));
+    var props = {
+      years: [2013, 2013],
+      start: start,
+      end: end
+    };
+    var validation = (0, _PropValidation.propValidation)(props);
+    expect(validation).toEqual(true);
+  });
+  it('No prop error when years start date before end', function () {
+    var start = (0, _moment.default)(new Date(2013, 1, 1, 0, 0, 0, 0));
+    var end = (0, _moment.default)(new Date(2013, 1, 1, 0, 0, 0, 0));
+    var props = {
+      years: [2010, 2013],
+      start: start,
+      end: end
+    };
+    var validation = (0, _PropValidation.propValidation)(props);
+    expect(validation).toEqual(true);
+  });
+});

--- a/dist/tests/utils_tests/StyleUtils.test.js
+++ b/dist/tests/utils_tests/StyleUtils.test.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _StyleUtils = require("../../utils/StyleUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_moment.default.locale('en');
+
+describe('Time Function Utils Tests', function () {
+  it('Add Focus Style', function () {
+    var styleMock = {
+      mock: true
+    };
+    var style = (0, _StyleUtils.addFocusStyle)(true, styleMock);
+    expect(style.outline).toEqual('cornflowerblue');
+    expect(style.outlineStyle).toEqual('auto');
+  });
+  it('No Focus Style', function () {
+    var styleMock = {
+      mock: true
+    };
+    var style = (0, _StyleUtils.addFocusStyle)(false, styleMock);
+    expect(style.outlineStyle).toEqual('');
+  });
+});

--- a/dist/tests/utils_tests/TimeFunctionUtils.test.js
+++ b/dist/tests/utils_tests/TimeFunctionUtils.test.js
@@ -1,0 +1,91 @@
+"use strict";
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _TimeFunctionUtils = require("../../utils/TimeFunctionUtils");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+_moment.default.locale('en');
+
+describe('Time Function Utils Tests', function () {
+  it('Invalid Style Contains not-allowed cursor', function () {
+    var style = (0, _TimeFunctionUtils.invalidStyle)();
+    expect(style.cursor).toEqual('not-allowed');
+  });
+  it('Hover Style non between returns 4px border', function () {
+    var style = (0, _TimeFunctionUtils.hoverCellStyle)(false);
+    expect(style.borderRadius).toEqual('4px 4px 4px 4px');
+  });
+  it('Hover Style non between returns 0px border', function () {
+    var style = (0, _TimeFunctionUtils.hoverCellStyle)(true);
+    expect(style.borderRadius).toEqual('0 0 0 0');
+  });
+  it('In Between Style returns pointer cursor', function () {
+    var style = (0, _TimeFunctionUtils.inBetweenStyle)();
+    expect(style.cursor).toEqual('pointer');
+  });
+  it('Is Valid Time Change Mode Start, Start before End', function () {
+    var startDate = (0, _moment.default)();
+    var endDate = (0, _moment.default)();
+    var outcome = (0, _TimeFunctionUtils.isValidTimeChange)('start', startDate, startDate, endDate);
+    expect(outcome).toEqual(true);
+  });
+  it('Is invalid Time Change Mode Start, End before Start', function () {
+    var startDate = (0, _moment.default)();
+    startDate.add(1, 'days');
+    var endDate = (0, _moment.default)();
+    var outcome = (0, _TimeFunctionUtils.isValidTimeChange)('start', startDate, startDate, endDate);
+    expect(outcome).toEqual(false);
+  });
+  it('Is Valid Time Change Mode End, End before Start', function () {
+    var startDate = (0, _moment.default)();
+    var endDate = (0, _moment.default)();
+    endDate.subtract(1, 'days');
+    var outcome = (0, _TimeFunctionUtils.isValidTimeChange)('end', endDate, startDate, endDate);
+    expect(outcome).toEqual(false);
+  });
+  it('Is Valid Time Change Mode End, End after Start', function () {
+    var startDate = (0, _moment.default)();
+    var endDate = (0, _moment.default)();
+    var outcome = (0, _TimeFunctionUtils.isValidTimeChange)('end', endDate, startDate, endDate);
+    expect(outcome).toEqual(true);
+  });
+  it('Work Out Month, Both Months Different Months', function () {
+    var startDate = (0, _moment.default)(new Date(2018, 0, 1));
+    startDate.subtract(1, 'month');
+    var endDate = (0, _moment.default)(new Date(2018, 0, 2));
+    var outcome = (0, _TimeFunctionUtils.getMonth)(startDate, endDate, 'start');
+    expect(outcome).toEqual(11);
+  });
+  it('Work Out Month, Both Months Same Months and Same Year, Start mode, PastFriendly so previous month expected', function () {
+    var startDate = (0, _moment.default)(new Date(2018, 0, 1));
+    var endDate = (0, _moment.default)(new Date(2018, 0, 2));
+    var outcome = (0, _TimeFunctionUtils.getMonth)(startDate, endDate, 'start', true, true);
+    expect(outcome).toEqual(11);
+  });
+  it('Work Out Month, Both Months Same Months and Same Year, End mode, PastFriendly so previous month expected', function () {
+    var startDate = (0, _moment.default)(new Date(2018, 0, 1));
+    var endDate = (0, _moment.default)(new Date(2018, 0, 2));
+    var outcome = (0, _TimeFunctionUtils.getMonth)(startDate, endDate, 'end', true, true);
+    expect(outcome).toEqual(0);
+  });
+  it('Work Out Month, Both Months Same Months and Same Year, Start mode, not PastFriendly so same month expected', function () {
+    var startDate = (0, _moment.default)(new Date(2018, 0, 1));
+    var endDate = (0, _moment.default)(new Date(2018, 0, 2));
+    var outcome = (0, _TimeFunctionUtils.getMonth)(startDate, endDate, 'start', false, true);
+    expect(outcome).toEqual(0);
+  });
+  it('Work Out Month, Both Months Same Months and Same Year, not PastFriendly so next month expected', function () {
+    var startDate = (0, _moment.default)(new Date(2018, 0, 1));
+    var endDate = (0, _moment.default)(new Date(2018, 0, 2));
+    var outcome = (0, _TimeFunctionUtils.getMonth)(startDate, endDate, 'end', false, true);
+    expect(outcome).toEqual(1);
+  });
+  it('Work Out Month, Both Months Same Months and Different Year', function () {
+    var startDate = (0, _moment.default)(new Date(2017, 0, 1));
+    var endDate = (0, _moment.default)(new Date(2018, 0, 2));
+    var outcome = (0, _TimeFunctionUtils.getMonth)(startDate, endDate, 'start');
+    expect(outcome).toEqual(0);
+  });
+});

--- a/dist/utils/BrowserVersion.js
+++ b/dist/utils/BrowserVersion.js
@@ -1,0 +1,60 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.isFirefoxBelow53 = exports.browserVersion = void 0;
+
+var browserVersion = function browserVersion() {
+  var ua = navigator.userAgent,
+      tem,
+      M = ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+
+  if (/trident/i.test(M[1])) {
+    tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
+    return "IE ".concat(tem[1] || '');
+  }
+
+  if (M[1] === 'Chrome') {
+    tem = ua.match(/\b(OPR|Edge)\/(\d+)/);
+    if (tem != null) return tem.slice(1).join(' ').replace('OPR', 'Opera');
+  }
+
+  M = M[2] ? [M[1], M[2]] : [navigator.appName, navigator.appVersion, '-?'];
+  if ((tem = ua.match(/version\/(\d+)/i)) != null) M.splice(1, 1, tem[1]);
+  return M.join(' ');
+};
+
+exports.browserVersion = browserVersion;
+
+var isFirefoxBelow53 = function isFirefoxBelow53() {
+  var browser = browserVersion();
+
+  if (!browser) {
+    return false;
+  }
+
+  var browserSplit = browser.split(' ');
+
+  if (browserSplit.length !== 2) {
+    return false;
+  }
+
+  if (browserSplit[0] !== 'Firefox') {
+    return false;
+  }
+
+  try {
+    var versionNumber = Number.parseInt(browserSplit[1]);
+
+    if (versionNumber <= 52) {
+      return true;
+    }
+  } catch (e) {
+    return false;
+  }
+
+  return false;
+};
+
+exports.isFirefoxBelow53 = isFirefoxBelow53;

--- a/dist/utils/CssClassNameHelper.js
+++ b/dist/utils/CssClassNameHelper.js
@@ -1,0 +1,44 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.getCalendarGridCellClassName = exports.getCalendarGridHeaderClassName = exports.getCalendarGridClassName = void 0;
+
+var _BrowserVersion = require("./BrowserVersion");
+
+var getCalendarGridClassName = function getCalendarGridClassName() {
+  var firefoxBelow35 = (0, _BrowserVersion.isFirefoxBelow53)();
+
+  if (firefoxBelow35) {
+    return 'calendarGridFirefoxBelow35';
+  } else {
+    return 'calendarGrid';
+  }
+};
+
+exports.getCalendarGridClassName = getCalendarGridClassName;
+
+var getCalendarGridHeaderClassName = function getCalendarGridHeaderClassName() {
+  var firefoxBelow35 = (0, _BrowserVersion.isFirefoxBelow53)();
+
+  if (firefoxBelow35) {
+    return 'calendarGridHeaderFirefoxBelow35';
+  } else {
+    return;
+  }
+};
+
+exports.getCalendarGridHeaderClassName = getCalendarGridHeaderClassName;
+
+var getCalendarGridCellClassName = function getCalendarGridCellClassName() {
+  var firefoxBelow35 = (0, _BrowserVersion.isFirefoxBelow53)();
+
+  if (firefoxBelow35) {
+    return 'calendarCellFirefoxBelow35';
+  } else {
+    return 'calendarCell';
+  }
+};
+
+exports.getCalendarGridCellClassName = getCalendarGridCellClassName;

--- a/dist/utils/DateSelectedUtils.js
+++ b/dist/utils/DateSelectedUtils.js
@@ -1,0 +1,86 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.pastMaxDate = exports.datePicked = void 0;
+
+var _moment = _interopRequireDefault(require("moment"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var datePicked = function datePicked(startDate, endDate, newDate, startMode, smartMode) {
+  if (startMode) {
+    return newDateStartMode(newDate, endDate, smartMode, startDate);
+  } else {
+    return newDateEndMode(newDate, startDate, smartMode, endDate);
+  }
+};
+
+exports.datePicked = datePicked;
+
+var newDateStartMode = function newDateStartMode(newDate, endDate, smartMode, startDate) {
+  // Create a new moment object which combines the new date and the original start date as newDate
+  // doesnt contain time info which is important to determining equality
+  var newDateWithTime = createNewDateWithTime(newDate, startDate.hour(), startDate.minute(), startDate.second());
+
+  if (newDateWithTime.isSameOrBefore(endDate, 'seconds')) {
+    return returnDateObject(newDate, endDate);
+  } else if (smartMode) {
+    var newEnd = (0, _moment.default)(newDate);
+    newEnd.add(1, 'days');
+    return returnDateObject(newDate, newEnd);
+  } else {
+    return returnDateObject(startDate, endDate);
+  }
+};
+
+var newDateEndMode = function newDateEndMode(newDate, startDate, smartMode, endDate) {
+  // Create a new moment object which combines the new date and the original end date as newDate
+  // doesnt contain time info which is important to determining equality
+  var newDateWithTime = createNewDateWithTime(newDate, endDate.hour(), endDate.minute(), endDate.second());
+
+  if (newDateWithTime.isSameOrAfter(startDate, 'seconds')) {
+    return returnDateObject(startDate, newDate);
+  } else if (smartMode) {
+    var newStart = (0, _moment.default)(newDate);
+    newStart.subtract(1, 'days');
+    return returnDateObject(newStart, newDate);
+  } else {
+    return returnDateObject(startDate, endDate);
+  }
+};
+
+var createNewDateWithTime = function createNewDateWithTime(newDate, hour, minute, second) {
+  var newDateTmp = [newDate.year(), newDate.month(), newDate.date()];
+  var newDateWithTime = (0, _moment.default)(newDateTmp);
+  newDateWithTime.hour(hour);
+  newDateWithTime.minute(minute);
+  newDateWithTime.second(second);
+  return newDateWithTime;
+};
+
+var returnDateObject = function returnDateObject(startDate, endDate) {
+  var returnValues = {};
+  returnValues.startDate = startDate;
+  returnValues.endDate = endDate;
+  return returnValues;
+};
+
+var pastMaxDate = function pastMaxDate(currentDate, maxDate, minuteMode) {
+  if (!maxDate) {
+    return false;
+  }
+
+  if (minuteMode && maxDate && currentDate.isAfter(maxDate, 'seconds')) {
+    return true;
+  }
+
+  if (maxDate && currentDate.isAfter(maxDate, 'day')) {
+    return true;
+  }
+
+  return false;
+};
+
+exports.pastMaxDate = pastMaxDate;

--- a/dist/utils/PropValidation.js
+++ b/dist/utils/PropValidation.js
@@ -1,0 +1,43 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.propValidation = void 0;
+
+var propValidation = function propValidation(props) {
+  if (props.years) {
+    if (!Array.isArray(props.years)) {
+      return 'Year props should be an array e.g. [2019, 2020]';
+    }
+
+    if (props.years.length !== 2) {
+      return 'Year props should be an array of 2, with the first number being the start date and the second being the end';
+    }
+
+    var start = props.start,
+        end = props.end,
+        years = props.years;
+
+    if (years[0] > years[1]) {
+      return 'Start year must be before the end';
+    } // Start year defined must be between the custom user defined dates
+
+
+    var isStartYearBetweenUserDefinedYears = start.year() >= years[0] && start.year() <= years[1]; // End year defined must be between the custom user defined dates
+
+    var isEndYearBetweenUserDefinedYears = end.year() >= years[0] && end.year() <= years[1];
+
+    if (!isStartYearBetweenUserDefinedYears) {
+      return 'Start year should be in the custom years defined';
+    }
+
+    if (!isEndYearBetweenUserDefinedYears) {
+      return 'End year should be in the custom years defined';
+    }
+  }
+
+  return true;
+};
+
+exports.propValidation = propValidation;

--- a/dist/utils/StyleUtils.js
+++ b/dist/utils/StyleUtils.js
@@ -1,0 +1,33 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.darkTheme = exports.lightTheme = exports.addFocusStyle = void 0;
+
+var addFocusStyle = function addFocusStyle(focused, currentStyle) {
+  var style = JSON.parse(JSON.stringify(currentStyle));
+
+  if (focused) {
+    style.outline = 'cornflowerblue';
+    style.outlineStyle = 'auto';
+  } else {
+    style.outlineStyle = '';
+  }
+
+  return style;
+};
+
+exports.addFocusStyle = addFocusStyle;
+var white = '#FFFFFF';
+var black = '#161617';
+var lightTheme = {
+  background: white,
+  color: black
+};
+exports.lightTheme = lightTheme;
+var darkTheme = {
+  background: black,
+  color: white
+};
+exports.darkTheme = darkTheme;

--- a/dist/utils/TimeFunctionUtils.js
+++ b/dist/utils/TimeFunctionUtils.js
@@ -1,0 +1,326 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.rangeButtonStyle = exports.rangeButtonSelectedStyle = exports.invalidStyle = exports.greyCellStyle = exports.hoverCellStyle = exports.normalCellStyle = exports.inBetweenStyle = exports.endDateStyle = exports.startDateStyle = exports.isValidTimeChange = exports.isInbetweenDates = exports.getFourtyTwoDays = exports.getYear = exports.getMonth = exports.generateMinutes = exports.generateHours = void 0;
+
+var _moment = _interopRequireDefault(require("moment"));
+
+var _DateTimeRangePicker = require("../DateTimeRangePicker");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var generateHours = function generateHours() {
+  var hours = [];
+
+  for (var i = 0; i < 24; i++) {
+    hours.push(i);
+  }
+
+  return hours;
+};
+
+exports.generateHours = generateHours;
+
+var generateMinutes = function generateMinutes() {
+  var minutes = [];
+
+  for (var i = 0; i < 60; i++) {
+    if (i < 10) {
+      minutes.push("0".concat(i.toString()));
+    } else {
+      minutes.push(i.toString());
+    }
+  }
+
+  return minutes;
+};
+
+exports.generateMinutes = generateMinutes;
+
+function workOutMonthYear(date, secondDate, mode, pastSearchFriendly, smartMode) {
+  // If both months are different months then
+  // allow normal display in the calendar
+  var selectedMonth = date.month();
+  var otherMonth = secondDate.month();
+
+  if (selectedMonth !== otherMonth) {
+    return date;
+  } // If pastSearch Friendly mode is on and both months are the same and the same year
+  // have "end"/right as the month and "start"/left as -1 month
+  else if (date.year() === secondDate.year() && mode === _DateTimeRangePicker.ModeEnum.start && pastSearchFriendly && smartMode) {
+      var lastMonth = JSON.parse(JSON.stringify(date));
+      lastMonth = (0, _moment.default)(lastMonth);
+      lastMonth.subtract(1, 'month');
+      return lastMonth;
+    } // If pastSearch Friendly mode is off and both months are the same and the same year
+    // have "end"/right as the month and "start"/left as +1 month
+    else if (date.year() === secondDate.year() && mode === _DateTimeRangePicker.ModeEnum.end && !pastSearchFriendly && smartMode) {
+        var _lastMonth = JSON.parse(JSON.stringify(date));
+
+        _lastMonth = (0, _moment.default)(_lastMonth);
+
+        _lastMonth.add(1, 'month');
+
+        return _lastMonth;
+      } else {
+        return date;
+      }
+}
+
+var getMonth = function getMonth(date, secondDate, mode, pastSearchFriendly, smartMode) {
+  return workOutMonthYear(date, secondDate, mode, pastSearchFriendly, smartMode).month();
+};
+
+exports.getMonth = getMonth;
+
+var getYear = function getYear(date, secondDate, mode, pastSearchFriendly, smartMode) {
+  return workOutMonthYear(date, secondDate, mode, pastSearchFriendly, smartMode).year();
+};
+
+exports.getYear = getYear;
+
+var getDaysBeforeStartMonday = function getDaysBeforeStartMonday(firstDayOfMonth) {
+  var fourtyTwoDays = [];
+  var dayBeforeFirstDayOfMonth = firstDayOfMonth.day() - 1; // We dont want to include the first day of the new month
+  // Case whereby day before is a Saturday (6) and we require Saturday back to Monday for that week
+
+  if (dayBeforeFirstDayOfMonth === -1) {
+    for (var i = 6; i > 0; i--) {
+      var firstDayOfMonthCopy = firstDayOfMonth.clone();
+      firstDayOfMonthCopy = firstDayOfMonthCopy.subtract(i, 'd');
+      fourtyTwoDays.push(firstDayOfMonthCopy);
+    }
+  } // Case Whereby day before first day is the Sunday (0), therefore we want the entire previous week
+
+
+  if (dayBeforeFirstDayOfMonth === 0) {
+    for (var _i = 7; _i > 0; _i--) {
+      var _firstDayOfMonthCopy = firstDayOfMonth.clone();
+
+      _firstDayOfMonthCopy = _firstDayOfMonthCopy.subtract(_i, 'd');
+      fourtyTwoDays.push(_firstDayOfMonthCopy);
+    }
+  } // Every other day
+  else {
+      for (var _i2 = dayBeforeFirstDayOfMonth; _i2 > 0; _i2--) {
+        var _firstDayOfMonthCopy2 = firstDayOfMonth.clone();
+
+        _firstDayOfMonthCopy2 = _firstDayOfMonthCopy2.subtract(_i2, 'd');
+        fourtyTwoDays.push(_firstDayOfMonthCopy2);
+      }
+    }
+
+  return fourtyTwoDays;
+};
+
+var getDaysBeforeStartSunday = function getDaysBeforeStartSunday(firstDayOfMonth) {
+  var fourtyTwoDays = [];
+  var dayBeforeFirstDayOfMonth = firstDayOfMonth.day() - 1; // We dont want to include the first day of the new month
+  // Case whereby we need all previous week days
+
+  if (dayBeforeFirstDayOfMonth === -1) {
+    for (var i = 7; i > 0; i--) {
+      var firstDayOfMonthCopy = firstDayOfMonth.clone();
+      firstDayOfMonthCopy = firstDayOfMonthCopy.subtract(i, 'd');
+      fourtyTwoDays.push(firstDayOfMonthCopy);
+    }
+  } // Every other day
+  else {
+      for (var _i3 = dayBeforeFirstDayOfMonth + 1; _i3 > 0; _i3--) {
+        var _firstDayOfMonthCopy3 = firstDayOfMonth.clone();
+
+        _firstDayOfMonthCopy3 = _firstDayOfMonthCopy3.subtract(_i3, 'd');
+        fourtyTwoDays.push(_firstDayOfMonthCopy3);
+      }
+    }
+
+  return fourtyTwoDays;
+};
+
+var getDaysBeforeStart = function getDaysBeforeStart(firstDayOfMonth, sundayFirst) {
+  if (!sundayFirst) {
+    return getDaysBeforeStartMonday(firstDayOfMonth);
+  } else {
+    return getDaysBeforeStartSunday(firstDayOfMonth);
+  }
+};
+
+var getFourtyTwoDays = function getFourtyTwoDays(initMonth, initYear, sundayFirst) {
+  var fourtyTwoDays = [];
+  var firstDayOfMonth = (0, _moment.default)(new Date(initYear, initMonth, 1));
+  fourtyTwoDays = getDaysBeforeStart(firstDayOfMonth, sundayFirst); // Add in all days this month
+
+  for (var i = 0; i < firstDayOfMonth.daysInMonth(); i++) {
+    fourtyTwoDays.push(firstDayOfMonth.clone().add(i, 'd'));
+  } // Add in all days at the end of the month until last day of week seen
+
+
+  var lastDayOfMonth = (0, _moment.default)(new Date(initYear, initMonth, firstDayOfMonth.daysInMonth()));
+  var toAdd = 1;
+  var gotAllDays = false;
+
+  while (!gotAllDays) {
+    if (fourtyTwoDays.length >= 42) {
+      gotAllDays = true;
+      break;
+    }
+
+    fourtyTwoDays.push(lastDayOfMonth.clone().add(toAdd, 'd'));
+    toAdd++;
+  }
+
+  return fourtyTwoDays;
+};
+
+exports.getFourtyTwoDays = getFourtyTwoDays;
+
+var isInbetweenDates = function isInbetweenDates(isStartDate, dayToFindOut, start, end) {
+  var isInBetweenDates;
+
+  if (isStartDate) {
+    isInBetweenDates = dayToFindOut.isAfter(start) && dayToFindOut.isBefore(end);
+  } else {
+    isInBetweenDates = dayToFindOut.isBefore(start) && dayToFindOut.isAfter(end);
+  }
+
+  return isInBetweenDates;
+};
+
+exports.isInbetweenDates = isInbetweenDates;
+
+var isValidTimeChange = function isValidTimeChange(mode, date, start, end) {
+  var modeStartAndDateSameOrBeforeStart = mode === 'start' && date.isSameOrBefore(end);
+  var modeEndAndDateSameOrAfterEnd = mode === 'end' && date.isSameOrAfter(start);
+  return modeStartAndDateSameOrBeforeStart || modeEndAndDateSameOrAfterEnd;
+};
+
+exports.isValidTimeChange = isValidTimeChange;
+
+var startDateStyle = function startDateStyle() {
+  return {
+    borderRadius: '4px 0 0 4px',
+    borderColour: 'transparent',
+    color: '#fff',
+    backgroundColor: '#357abd',
+    cursor: 'pointer'
+  };
+};
+
+exports.startDateStyle = startDateStyle;
+
+var endDateStyle = function endDateStyle() {
+  return {
+    borderRadius: '0 4px 4px 0',
+    borderColour: 'transparent',
+    color: '#fff',
+    backgroundColor: '#357abd',
+    cursor: 'pointer'
+  };
+};
+
+exports.endDateStyle = endDateStyle;
+
+var inBetweenStyle = function inBetweenStyle() {
+  return {
+    borderRadius: '0',
+    borderColour: 'transparent',
+    color: '#000',
+    backgroundColor: '#ebf4f8',
+    cursor: 'pointer'
+  };
+};
+
+exports.inBetweenStyle = inBetweenStyle;
+
+var normalCellStyle = function normalCellStyle(darkMode) {
+  var color = darkMode ? 'white' : 'black';
+  return {
+    borderRadius: '0 0 0 0',
+    borderColour: 'transparent',
+    color: color,
+    backgroundColor: ''
+  };
+};
+
+exports.normalCellStyle = normalCellStyle;
+
+var hoverCellStyle = function hoverCellStyle(between, darkMode) {
+  var borderRadius = '4px 4px 4px 4px';
+  var color = darkMode ? 'white' : 'black';
+  var backgroundColor = darkMode ? 'rgb(53, 122, 189)' : '#eee';
+
+  if (between) {
+    borderRadius = '0 0 0 0';
+  }
+
+  return {
+    borderRadius: borderRadius,
+    borderColour: 'transparent',
+    color: color,
+    backgroundColor: backgroundColor,
+    cursor: 'pointer'
+  };
+};
+
+exports.hoverCellStyle = hoverCellStyle;
+
+var greyCellStyle = function greyCellStyle(darkMode) {
+  var color = darkMode ? '#ffffff' : '#999';
+  var backgroundColor = darkMode ? '#777777' : '#fff';
+  var opacity = darkMode ? '0.5' : '0.25';
+  var borderRadius = '4px 4px 4px 4px';
+  return {
+    borderRadius: borderRadius,
+    borderColour: 'transparent',
+    color: color,
+    backgroundColor: backgroundColor,
+    cursor: 'pointer',
+    opacity: opacity
+  };
+};
+
+exports.greyCellStyle = greyCellStyle;
+
+var invalidStyle = function invalidStyle(darkMode) {
+  var style = greyCellStyle(darkMode);
+  style.cursor = 'not-allowed';
+  return style;
+};
+
+exports.invalidStyle = invalidStyle;
+
+var rangeButtonSelectedStyle = function rangeButtonSelectedStyle() {
+  return {
+    color: '#f5f5f5',
+    fontSize: '13px',
+    border: '1px solid #f5f5f5',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    marginBottom: '8px',
+    marginLeft: '4px',
+    marginRight: '4px',
+    marginTop: '4px',
+    backgroundColor: '#08c'
+  };
+};
+
+exports.rangeButtonSelectedStyle = rangeButtonSelectedStyle;
+
+var rangeButtonStyle = function rangeButtonStyle() {
+  return {
+    color: '#08c',
+    fontSize: '13px',
+    backgroundColor: '#f5f5f5',
+    border: '1px solid #f5f5f5',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    marginBottom: '8px',
+    marginLeft: '4px',
+    marginRight: '4px',
+    marginTop: '4px'
+  };
+};
+
+exports.rangeButtonStyle = rangeButtonStyle;

--- a/dist/utils/YearUtils.js
+++ b/dist/utils/YearUtils.js
@@ -1,0 +1,51 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.createYears = void 0;
+
+var _moment = _interopRequireDefault(require("moment"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var createYears = function createYears(userDefinedYears, descendingYears) {
+  var years = [];
+
+  if (!userDefinedYears) {
+    //Range from 1900 to 25 years into the future
+    var past = (0, _moment.default)('19000101', 'YYYYMMDD');
+    var yearsToGetFuture = 10;
+    var endYear = (0, _moment.default)().add(yearsToGetFuture, 'years').get('year');
+    var addedCurrentYear = false;
+
+    while (!addedCurrentYear) {
+      if (past.get('years') === endYear) {
+        addedCurrentYear = true;
+      }
+
+      years.push(past.year());
+      past.add(1, 'years');
+    }
+  } else {
+    var start = userDefinedYears[0];
+    var end = userDefinedYears[1];
+
+    for (var i = start; i <= end; i++) {
+      years.push(i);
+    }
+  }
+
+  return sortYears(years, descendingYears);
+};
+
+exports.createYears = createYears;
+
+var sortYears = function sortYears(years, descendingYears) {
+  // Decides whether to order dates in ascending or descending order
+  if (descendingYears) {
+    return years.reverse();
+  }
+
+  return years;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advanced-datetimerange-picker",
-  "version": "1.0.7",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advanced-datetimerange-picker",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "license": "GNU",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/lib/DateTimeRangeContainer.jsx
+++ b/src/lib/DateTimeRangeContainer.jsx
@@ -40,6 +40,11 @@ class DateTimeRangeContainer extends React.Component {
     document.removeEventListener('keydown', this.keyDown, false);
   }
 
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.resize);
+    document.removeEventListener('keydown', this.keyDown, false);
+  }
+
   componentDidUpdate(prevProps) {
     // If the left mode prop has been updated from the Parent treat it like a rezise
     // and adjust the layout accordingly


### PR DESCRIPTION
When leaving the screen where the datepicker component is rendered and resizing the browser window, the resize and keydown events were still active exposing errors in the browser console: it is not possible to find the node in a disassembled component. The componentWillUnmount function was implemented to reset the resize and keydown events.