### PR TITLE
Fix leftover event handler after component unmount

### DIFF
--- a/src/lib/DateTimeRangeContainer.jsx
+++ b/src/lib/DateTimeRangeContainer.jsx
@@ -38,6 +38,7 @@ class DateTimeRangeContainer extends React.Component {
   componentWillUnmount() {
     window.removeEventListener('resize', this.resize);
     document.removeEventListener('keydown', this.keyDown, false);
+    document.removeEventListener('click', this.handleOutsideClick, false);
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
The `handleOutsideClick` handler sticks around after component unmount if the picker is open. When the handler executes, and exception is thrown because `container` is null at that point. 